### PR TITLE
Add provider orchestration Edge Functions and DigitalOcean adapter

### DIFF
--- a/supabase/functions/_shared/digitalocean.ts
+++ b/supabase/functions/_shared/digitalocean.ts
@@ -1,0 +1,90 @@
+import { providerEnv } from "./provider-env.ts";
+import { ProvisionRequest, ProviderServicePayload, QuoteRequest } from "./provider.ts";
+
+const DO_BASE = "https://api.digitalocean.com/v2";
+
+function authHeaders(idempotencyKey?: string) {
+	return {
+		Authorization: `Bearer ${providerEnv.digitalOceanToken}`,
+		"Content-Type": "application/json",
+		...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}),
+	};
+}
+
+function normalizeState(status?: string): ProviderServicePayload["state"] {
+	if (!status) return "pending";
+	if (["new", "in-progress", "off", "archive"].includes(status)) return "pending";
+	if (["active", "running", "ok"].includes(status)) return "active";
+	if (["deleting"].includes(status)) return "deleting";
+	return "failed";
+}
+
+function sanitizeDroplet(droplet: Record<string, any>): ProviderServicePayload {
+	return {
+		id: String(droplet.id),
+		name: droplet.name,
+		region: droplet.region?.slug,
+		size: droplet.size_slug,
+		image: droplet.image?.slug,
+		createdAt: droplet.created_at,
+		ipv4: (droplet.networks?.v4 ?? []).map((n: any) => n.ip_address).filter(Boolean),
+		state: normalizeState(droplet.status),
+	};
+}
+
+async function doFetch(path: string, init?: RequestInit) {
+	const response = await fetch(`${DO_BASE}${path}`, init);
+	const text = await response.text();
+	const json = text ? JSON.parse(text) : {};
+	if (!response.ok) {
+		throw new Error(json?.message || `DigitalOcean error (${response.status})`);
+	}
+	return json;
+}
+
+export const digitalOceanAdapter = {
+	compute: {
+		async quote(request: QuoteRequest) {
+			const list = await doFetch("/sizes", { headers: authHeaders() });
+			const target = (list.sizes ?? []).find((s: any) => s.slug === request.size);
+			const hourly = Number(target?.price_hourly ?? 0);
+			const monthly = Number(target?.price_monthly ?? 0);
+			const quantity = Math.max(1, Number(request.quantity ?? 1));
+			return {
+				region: request.region,
+				size: request.size,
+				quantity,
+				hourlyTotal: hourly * quantity,
+				monthlyTotal: monthly * quantity,
+				currency: "USD",
+			};
+		},
+		async provision(request: ProvisionRequest, idempotencyKey: string) {
+			const payload = await doFetch("/droplets", {
+				method: "POST",
+				headers: authHeaders(idempotencyKey),
+				body: JSON.stringify({
+					name: request.name,
+					region: request.region,
+					size: request.size,
+					image: request.image,
+					tags: request.tags ?? [],
+				}),
+			});
+			return sanitizeDroplet(payload.droplet ?? {});
+		},
+		async getStatus(id: string) {
+			const payload = await doFetch(`/droplets/${id}`, { headers: authHeaders() });
+			return sanitizeDroplet(payload.droplet ?? {});
+		},
+		async lifecycle(id: string, action: "start"|"stop"|"resize"|"delete", idempotencyKey: string, resizeSize?: string) {
+			if (action === "delete") {
+				await doFetch(`/droplets/${id}`, { method: "DELETE", headers: authHeaders(idempotencyKey) });
+				return { id, state: "deleting" as const };
+			}
+			const body = action === "resize" ? { type: "resize", size: resizeSize, disk: false } : { type: action === "start" ? "power_on" : "power_off" };
+			await doFetch(`/droplets/${id}/actions`, { method: "POST", headers: authHeaders(), body: JSON.stringify(body) });
+			return this.getStatus(id);
+		},
+	},
+};

--- a/supabase/functions/_shared/provider-env.ts
+++ b/supabase/functions/_shared/provider-env.ts
@@ -1,0 +1,11 @@
+function requiredEnv(name: string) {
+	const value = Deno.env.get(name);
+	if (!value) {
+		throw new Error(`Missing required environment variable: ${name}`);
+	}
+	return value;
+}
+
+export const providerEnv = (() => ({
+	digitalOceanToken: requiredEnv("DO_API_TOKEN"),
+}))();

--- a/supabase/functions/_shared/provider.ts
+++ b/supabase/functions/_shared/provider.ts
@@ -1,0 +1,26 @@
+export type InternalProvisionState = "pending" | "active" | "failed" | "deleting";
+
+export type ProviderServicePayload = {
+	id: string;
+	name?: string;
+	region?: string;
+	size?: string;
+	image?: string;
+	ipv4?: string[];
+	createdAt?: string;
+	state: InternalProvisionState;
+};
+
+export type ProvisionRequest = {
+	name: string;
+	region: string;
+	size: string;
+	image: string;
+	tags?: string[];
+};
+
+export type QuoteRequest = {
+	region: string;
+	size: string;
+	quantity?: number;
+};

--- a/supabase/functions/provider-lifecycle/index.ts
+++ b/supabase/functions/provider-lifecycle/index.ts
@@ -1,0 +1,21 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { digitalOceanAdapter } from "../_shared/digitalocean.ts";
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+	if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+	try {
+		const body = await request.json();
+		const action = String(body?.action || "").toLowerCase() as "start"|"stop"|"resize"|"delete";
+		if (!["start", "stop", "resize", "delete"].includes(action)) {
+			return jsonResponse({ error: "Invalid action." }, 400, request);
+		}
+		const id = String(body?.id || "");
+		const idempotencyKey = String(body?.idempotencyKey || crypto.randomUUID());
+		const service = await digitalOceanAdapter.compute.lifecycle(id, action, idempotencyKey, body?.size);
+		return jsonResponse({ service, idempotencyKey: action === "delete" ? idempotencyKey : undefined }, 200, request);
+	} catch (error) {
+		return jsonResponse({ error: error instanceof Error ? error.message : "Unable to apply lifecycle action." }, 500, request);
+	}
+});

--- a/supabase/functions/provider-provision/index.ts
+++ b/supabase/functions/provider-provision/index.ts
@@ -1,0 +1,22 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { digitalOceanAdapter } from "../_shared/digitalocean.ts";
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+	if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+	try {
+		const body = await request.json();
+		const idempotencyKey = String(body?.idempotencyKey || crypto.randomUUID());
+		const service = await digitalOceanAdapter.compute.provision({
+			name: String(body?.name || ""),
+			region: String(body?.region || ""),
+			size: String(body?.size || ""),
+			image: String(body?.image || "ubuntu-24-04-x64"),
+			tags: Array.isArray(body?.tags) ? body.tags : [],
+		}, idempotencyKey);
+		return jsonResponse({ service, idempotencyKey }, 200, request);
+	} catch (error) {
+		return jsonResponse({ error: error instanceof Error ? error.message : "Unable to provision service." }, 500, request);
+	}
+});

--- a/supabase/functions/provider-quote/index.ts
+++ b/supabase/functions/provider-quote/index.ts
@@ -1,0 +1,19 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { digitalOceanAdapter } from "../_shared/digitalocean.ts";
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+	if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+	try {
+		const body = await request.json();
+		const quote = await digitalOceanAdapter.compute.quote({
+			region: String(body?.region || ""),
+			size: String(body?.size || ""),
+			quantity: Number(body?.quantity ?? 1),
+		});
+		return jsonResponse({ quote }, 200, request);
+	} catch (error) {
+		return jsonResponse({ error: error instanceof Error ? error.message : "Unable to create quote." }, 500, request);
+	}
+});

--- a/supabase/functions/provider-sync-status/index.ts
+++ b/supabase/functions/provider-sync-status/index.ts
@@ -1,0 +1,16 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { digitalOceanAdapter } from "../_shared/digitalocean.ts";
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+	if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+	try {
+		const body = await request.json();
+		const id = String(body?.id || "");
+		const service = await digitalOceanAdapter.compute.getStatus(id);
+		return jsonResponse({ service }, 200, request);
+	} catch (error) {
+		return jsonResponse({ error: error instanceof Error ? error.message : "Unable to fetch service status." }, 500, request);
+	}
+});


### PR DESCRIPTION
### Motivation
- Provide provider orchestration endpoints to let the frontend request quotes, provision instances, run lifecycle actions, and sync status without depending on provider-specific APIs.
- Encapsulate DigitalOcean specifics behind a product-family adapter so frontend and higher-level logic can operate on normalized service objects.
- Keep provider credentials out of source and validate them at function cold start to avoid accidental leakage and surface missing-secret errors early.
- Prevent duplicate provisioning/delete retries by supporting idempotency keys for create/delete operations.

### Description
- Added a shared contract and types in `_shared/provider.ts` describing `ProvisionRequest`, `QuoteRequest`, `ProviderServicePayload`, and normalized internal states (`pending`, `active`, `failed`, `deleting`).
- Added `_shared/provider-env.ts` which reads and validates `DO_API_TOKEN` from the function environment at cold start.
- Implemented a DigitalOcean adapter in `_shared/digitalocean.ts` exposing `compute.quote`, `compute.provision`, `compute.getStatus`, and `compute.lifecycle`, with response sanitization and state normalization and passing `Idempotency-Key` for create/delete operations.
- Added four Supabase Edge Functions: `provider-quote`, `provider-provision`, `provider-lifecycle`, and `provider-sync-status`, each exposing a small POST API that returns sanitized payloads and accepts/generates idempotency keys where appropriate.

### Testing
- No automated tests were added or executed as part of this change; please run repository CI and existing unit/integration tests to validate runtime behavior and integration with DO credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f52dd774832b8a42b70773e84bdc)