### PR TITLE
Order-first provisioning: backend orchestration, edge function, and migration

### DIFF
--- a/src/lib/resellerApi.js
+++ b/src/lib/resellerApi.js
@@ -1,0 +1,24 @@
+import { supabase } from './supabaseClient'
+
+async function callProvisionEndpoint(payload) {
+  const { data, error } = await supabase.functions.invoke('provider-provision', { body: payload })
+  if (error) {
+    throw new Error(error.message || 'Provider orchestration failed.')
+  }
+  if (data?.error) {
+    throw new Error(data.error)
+  }
+  return data
+}
+
+export async function createServiceOrder(input) {
+  return callProvisionEndpoint({ action: 'create_order', ...input })
+}
+
+export async function confirmServicePayment(input) {
+  return callProvisionEndpoint({ action: 'confirm_payment', ...input })
+}
+
+export async function provisionService(input) {
+  return callProvisionEndpoint({ action: 'provision_service', ...input })
+}

--- a/src/pages/dashboard/NewService.jsx
+++ b/src/pages/dashboard/NewService.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { useDashboard } from '../../context/DashboardContext'
+import { createServiceOrder, confirmServicePayment, provisionService } from '../../lib/resellerApi'
 
 const serviceTypes = [
     { id: 'vps', name: 'Virtual Private Server', icon: 'server', description: 'High-performance NVMe VPS', price: '100 credits/mo', cost: 100, typeName: 'VPS (Standard)' },
@@ -20,7 +21,7 @@ const regions = [
 
 export default function NewService() {
     const navigate = useNavigate()
-    const { addResource, balance, deductCredits } = useDashboard()
+    const { addResource, balance } = useDashboard()
     const [selectedType, setSelectedType] = useState(serviceTypes[0].id)
     const [selectedRegion, setSelectedRegion] = useState(regions[0].id)
     const [isDeploying, setIsDeploying] = useState(false)
@@ -37,16 +38,26 @@ export default function NewService() {
         setDeployError('')
 
         try {
-            await deductCredits(`${selectedTypeInfo.typeName} deployment`, selectedTypeInfo.cost)
+            const orderResponse = await createServiceOrder({
+                serviceType: selectedTypeInfo.id,
+                serviceName: selectedTypeInfo.typeName,
+                region: regionInfo.id,
+                amountCredits: selectedTypeInfo.cost,
+                displayPrice: selectedTypeInfo.price,
+            })
+
+            await confirmServicePayment({ orderId: orderResponse.orderId })
+            const provisioned = await provisionService({ orderId: orderResponse.orderId })
+
             addResource({
-                name: `${selectedTypeInfo.id}-${Math.random().toString(36).substr(2, 5)}`,
+                name: provisioned.resource?.name || `${selectedTypeInfo.id}-${Math.random().toString(36).substr(2, 5)}`,
                 type: selectedTypeInfo.typeName,
                 region: regionInfo.id,
-                price: selectedTypeInfo.price
+                price: selectedTypeInfo.price,
             })
             navigate('/dashboard')
-        } catch {
-            setDeployError('Failed to deduct credits. Please try again.')
+        } catch (error) {
+            setDeployError(error instanceof Error ? error.message : 'Failed to deploy service. Please try again.')
         } finally {
             setIsDeploying(false)
         }

--- a/supabase/functions/provider-provision/index.ts
+++ b/supabase/functions/provider-provision/index.ts
@@ -1,0 +1,80 @@
+import { getCorsHeaders, jsonResponse } from '../_shared/cors.ts'
+import { createAdminClient, createUserClient } from '../_shared/supabase.ts'
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') return new Response('ok', { headers: getCorsHeaders(request) })
+  if (request.method !== 'POST') return jsonResponse({ error: 'Method not allowed.' }, 405, request)
+
+  try {
+    const authHeader = request.headers.get('Authorization')
+    const userClient = createUserClient(authHeader)
+    const adminClient = createAdminClient()
+    const { data: { user }, error: userError } = await userClient.auth.getUser()
+    if (userError || !user) return jsonResponse({ error: 'You must be signed in.' }, 401, request)
+
+    const body = await request.json()
+    const action = String(body?.action || '')
+
+    if (action === 'create_order') {
+      const { data: order, error: orderError } = await adminClient.from('orders').insert({ user_id: user.id, status: 'pending' }).select('id').single()
+      if (orderError || !order) return jsonResponse({ error: 'Unable to create order.' }, 500, request)
+
+      const { error: itemError } = await adminClient.from('order_items').insert({
+        order_id: order.id,
+        service_type: String(body?.serviceType || ''),
+        service_name: String(body?.serviceName || ''),
+        region: String(body?.region || ''),
+        amount_credits: Number(body?.amountCredits || 0),
+        display_price: String(body?.displayPrice || ''),
+      })
+      if (itemError) return jsonResponse({ error: 'Unable to create order item.' }, 500, request)
+
+      await adminClient.from('provision_events').insert({ order_id: order.id, event_type: 'order_created', details: { action } })
+      return jsonResponse({ orderId: order.id }, 200, request)
+    }
+
+    if (action === 'confirm_payment') {
+      const orderId = String(body?.orderId || '')
+      const { data: item } = await adminClient.from('order_items').select('id,amount_credits').eq('order_id', orderId).maybeSingle()
+      if (!item) return jsonResponse({ error: 'Order item not found.' }, 404, request)
+
+      const { error: debitError } = await adminClient.from('credit_transactions').insert({
+        user_id: user.id,
+        description: `Service order ${orderId}`,
+        amount: -Math.abs(Number(item.amount_credits || 0)),
+        type: 'debit',
+        status: 'Completed',
+      })
+      if (debitError) return jsonResponse({ error: 'Payment confirmation failed.' }, 500, request)
+
+      await adminClient.from('orders').update({ status: 'paid', paid_at: new Date().toISOString() }).eq('id', orderId).eq('user_id', user.id)
+      await adminClient.from('provision_events').insert({ order_id: orderId, event_type: 'payment_confirmed', details: { action } })
+      return jsonResponse({ orderId, status: 'paid' }, 200, request)
+    }
+
+    if (action === 'provision_service') {
+      const orderId = String(body?.orderId || '')
+      const { data: order } = await adminClient.from('orders').select('id,status,user_id').eq('id', orderId).maybeSingle()
+      if (!order || order.user_id !== user.id) return jsonResponse({ error: 'Order not found.' }, 404, request)
+      if (order.status !== 'paid') {
+        await adminClient.from('provision_events').insert({ order_id: orderId, event_type: 'provision_rejected_unpaid', details: { status: order.status } })
+        return jsonResponse({ error: 'Provisioning is only allowed for paid orders.' }, 422, request)
+      }
+
+      const { data: item } = await adminClient.from('order_items').select('id,service_type,service_name,region,display_price').eq('order_id', orderId).maybeSingle()
+      if (!item) return jsonResponse({ error: 'Order item not found.' }, 404, request)
+
+      const name = `${item.service_type}-${crypto.randomUUID().slice(0, 6)}`
+      const { data: resource, error: resourceError } = await adminClient.from('service_resources').insert({ order_item_id: item.id, name, service_type: item.service_name, region: item.region, price: item.display_price, status: 'active' }).select('id,name').single()
+      if (resourceError || !resource) return jsonResponse({ error: 'Provisioning failed.' }, 500, request)
+
+      await adminClient.from('orders').update({ status: 'provisioned', provisioned_at: new Date().toISOString() }).eq('id', orderId)
+      await adminClient.from('provision_events').insert({ order_id: orderId, order_item_id: item.id, service_resource_id: resource.id, event_type: 'service_provisioned', details: { resourceName: name } })
+      return jsonResponse({ orderId, resource }, 200, request)
+    }
+
+    return jsonResponse({ error: 'Unsupported action.' }, 400, request)
+  } catch (error) {
+    return jsonResponse({ error: error instanceof Error ? error.message : 'Unknown error.' }, 500, request)
+  }
+})

--- a/supabase/migrations/20260501120000_service_order_orchestration.sql
+++ b/supabase/migrations/20260501120000_service_order_orchestration.sql
@@ -1,0 +1,54 @@
+begin;
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending', 'paid', 'provisioned', 'failed')),
+  paid_at timestamptz,
+  provisioned_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.order_items (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  service_type text not null,
+  service_name text not null,
+  region text not null,
+  amount_credits integer not null check (amount_credits > 0),
+  display_price text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.service_resources (
+  id uuid primary key default gen_random_uuid(),
+  order_item_id uuid references public.order_items(id) on delete restrict,
+  name text not null,
+  service_type text not null,
+  region text not null,
+  price text not null,
+  status text not null default 'active',
+  created_at timestamptz not null default now()
+);
+
+alter table public.service_resources
+  alter column order_item_id set not null;
+
+create table if not exists public.provision_events (
+  id bigserial primary key,
+  order_id uuid not null references public.orders(id) on delete cascade,
+  order_item_id uuid references public.order_items(id) on delete set null,
+  service_resource_id uuid references public.service_resources(id) on delete set null,
+  event_type text not null,
+  details jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists orders_user_id_created_at_idx on public.orders(user_id, created_at desc);
+create index if not exists order_items_order_id_idx on public.order_items(order_id);
+create index if not exists provision_events_order_id_created_at_idx on public.provision_events(order_id, created_at desc);
+
+commit;


### PR DESCRIPTION
### Motivation
- Ensure provisioning is driven by a validated order/payment flow instead of direct client table writes to improve correctness and auditability.
- Centralize orchestration through a backend endpoint so payment/debit and provisioning logic are performed server-side with proper guards and observability.
- Restore strict DB invariants by removing the temporary nullable behavior for `service_resources.order_item_id` once order flow exists.
- Improve supportability by recording structured `provision_events` for every order-state transition.

### Description
- Updated `src/pages/dashboard/NewService.jsx` to call a backend orchestration flow that: creates an order + order_item, confirms payment, then invokes provisioning; UI still adds the provisioned resource locally for immediate feedback. (replaced client-side `deductCredits` usage with `createServiceOrder`, `confirmServicePayment`, `provisionService`).
- Added `src/lib/resellerApi.js` which routes lifecycle actions through a single `provider-provision` edge function via action-based payloads (`create_order`, `confirm_payment`, `provision_service`).
- Added a new Supabase Edge Function at `supabase/functions/provider-provision/index.ts` that creates `orders` and `order_items`, writes debit `credit_transactions` to confirm payment, enforces a paid-order guard before provisioning, provisions `service_resources`, and inserts `provision_events` for each transition (order_created, payment_confirmed, provision_rejected_unpaid, service_provisioned).
- Added DB migration `supabase/migrations/20260501120000_service_order_orchestration.sql` to create `orders`, `order_items`, `service_resources`, and `provision_events` and to restore `service_resources.order_item_id` to `NOT NULL`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40845f400832bba359ed8f61bf04a)