### PR TITLE
Add provider guardrails: validation, catalog allowlist, quotas, and audit logging

### DIFF
--- a/supabase/functions/_shared/provider-guard.ts
+++ b/supabase/functions/_shared/provider-guard.ts
@@ -1,0 +1,73 @@
+import { createAdminClient } from "./supabase.ts";
+
+const PLAN_CODE_RE = /^[a-z0-9][a-z0-9_-]{1,63}$/i;
+const REGION_RE = /^[a-z]{2,3}-[a-z]+-\d$/i;
+const IDEMPOTENCY_RE = /^[a-z0-9:_-]{12,128}$/i;
+
+export type ServiceAction = "start" | "stop" | "restart" | "delete";
+
+export interface BasePayload {
+  planCode: string;
+  region: string;
+  service_type: string;
+  idempotencyKey: string;
+}
+
+export function validateBasePayload(body: unknown): BasePayload {
+  const data = body as Record<string, unknown>;
+  if (!data || typeof data !== "object") {
+    throw new Error("Request body must be an object.");
+  }
+
+  const payload: BasePayload = {
+    planCode: String(data.planCode ?? "").trim(),
+    region: String(data.region ?? "").trim(),
+    service_type: String(data.service_type ?? "").trim(),
+    idempotencyKey: String(data.idempotencyKey ?? "").trim(),
+  };
+
+  if (!PLAN_CODE_RE.test(payload.planCode)) throw new Error("Invalid planCode format.");
+  if (!REGION_RE.test(payload.region)) throw new Error("Invalid region format.");
+  if (!PLAN_CODE_RE.test(payload.service_type)) throw new Error("Invalid service_type format.");
+  if (!IDEMPOTENCY_RE.test(payload.idempotencyKey)) throw new Error("Invalid idempotencyKey format.");
+
+  return payload;
+}
+
+export async function assertCatalogAllowlist(payload: BasePayload) {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("service_catalog")
+    .select("plan_code, region, service_type")
+    .eq("is_active", true)
+    .eq("plan_code", payload.planCode)
+    .eq("region", payload.region)
+    .eq("service_type", payload.service_type)
+    .maybeSingle();
+
+  if (error) throw new Error(`Catalog lookup failed: ${error.message}`);
+  if (!data) throw new Error("planCode/region/service_type are not in active service_catalog.");
+}
+
+export async function assertQuota(userId: string, table: string, hours: number, max: number, action?: string) {
+  const admin = createAdminClient();
+  const since = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+  let query = admin.from(table).select("id", { count: "exact", head: true }).eq("user_id", userId).gte("created_at", since);
+  if (action) query = query.eq("action", action);
+  const { count, error } = await query;
+  if (error) throw new Error(`Quota check failed: ${error.message}`);
+  if ((count ?? 0) >= max) throw new Error("Rate limit exceeded.");
+}
+
+export function rejectRestrictedClientFields(body: Record<string, unknown>, restricted: string[]) {
+  const supplied = restricted.filter((field) => body[field] !== undefined);
+  if (supplied.length > 0) {
+    throw new Error(`Client-controlled billing/provider fields are not allowed: ${supplied.join(", ")}`);
+  }
+}
+
+export function fingerprintRequest(request: Request, userId: string) {
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+  const ua = request.headers.get("user-agent") || "unknown";
+  return `${userId}:${ip}:${ua}`;
+}

--- a/supabase/functions/provider-lifecycle/index.ts
+++ b/supabase/functions/provider-lifecycle/index.ts
@@ -1,0 +1,42 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+import { assertCatalogAllowlist, assertQuota, fingerprintRequest, rejectRestrictedClientFields, ServiceAction, validateBasePayload } from "../_shared/provider-guard.ts";
+
+const ALLOWED_ACTIONS: ServiceAction[] = ["start", "stop", "restart", "delete"];
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  const authHeader = request.headers.get("Authorization");
+  const userClient = createUserClient(authHeader);
+  const adminClient = createAdminClient();
+  const { data: { user }, error } = await userClient.auth.getUser();
+  if (error || !user) return jsonResponse({ error: "Unauthorized." }, 401, request);
+
+  try {
+    const body = await request.json();
+    const action = String(body?.action ?? "").trim() as ServiceAction;
+    if (!ALLOWED_ACTIONS.includes(action)) throw new Error("Invalid lifecycle action.");
+
+    rejectRestrictedClientFields(body, ["provider_override", "billing_cycle", "price_override"]);
+    const payload = validateBasePayload(body);
+    await assertCatalogAllowlist(payload);
+    await assertQuota(user.id, "provision_events", 1 / 60, 10, action);
+
+    const actorFingerprint = fingerprintRequest(request, user.id);
+    const { error: eventError } = await adminClient.from("provision_events").insert({
+      user_id: user.id,
+      actor_id: user.id,
+      actor_type: "user",
+      request_fingerprint: actorFingerprint,
+      action,
+      metadata: { planCode: payload.planCode, region: payload.region, service_type: payload.service_type, idempotencyKey: payload.idempotencyKey },
+    });
+    if (eventError) return jsonResponse({ error: eventError.message }, 500, request);
+
+    return jsonResponse({ ok: true, accepted: true }, 202, request);
+  } catch (e) {
+    return jsonResponse({ error: e instanceof Error ? e.message : "Invalid request." }, 422, request);
+  }
+});

--- a/supabase/functions/provider-provision/index.ts
+++ b/supabase/functions/provider-provision/index.ts
@@ -1,0 +1,38 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+import { assertCatalogAllowlist, assertQuota, fingerprintRequest, rejectRestrictedClientFields, validateBasePayload } from "../_shared/provider-guard.ts";
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  const authHeader = request.headers.get("Authorization");
+  const userClient = createUserClient(authHeader);
+  const adminClient = createAdminClient();
+  const { data: { user }, error } = await userClient.auth.getUser();
+  if (error || !user) return jsonResponse({ error: "Unauthorized." }, 401, request);
+
+  try {
+    const body = await request.json();
+    rejectRestrictedClientFields(body, ["provider_sku", "unit_price", "provider", "billing_cycle", "overage_policy"]);
+    const payload = validateBasePayload(body);
+    await assertCatalogAllowlist(payload);
+    await assertQuota(user.id, "services", 24 * 365, 20);
+    await assertQuota(user.id, "provision_jobs", 1, 30);
+
+    const actorFingerprint = fingerprintRequest(request, user.id);
+    const { error: eventError } = await adminClient.from("provision_events").insert({
+      user_id: user.id,
+      actor_id: user.id,
+      actor_type: "user",
+      request_fingerprint: actorFingerprint,
+      action: "provision",
+      metadata: { planCode: payload.planCode, region: payload.region, service_type: payload.service_type, idempotencyKey: payload.idempotencyKey },
+    });
+    if (eventError) return jsonResponse({ error: eventError.message }, 500, request);
+
+    return jsonResponse({ ok: true, accepted: true }, 202, request);
+  } catch (e) {
+    return jsonResponse({ error: e instanceof Error ? e.message : "Invalid request." }, 422, request);
+  }
+});

--- a/supabase/functions/provider-quote/index.ts
+++ b/supabase/functions/provider-quote/index.ts
@@ -1,0 +1,23 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createUserClient } from "../_shared/supabase.ts";
+import { assertCatalogAllowlist, rejectRestrictedClientFields, validateBasePayload } from "../_shared/provider-guard.ts";
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  const authHeader = request.headers.get("Authorization");
+  const userClient = createUserClient(authHeader);
+  const { data: { user }, error } = await userClient.auth.getUser();
+  if (error || !user) return jsonResponse({ error: "Unauthorized." }, 401, request);
+
+  try {
+    const body = await request.json();
+    rejectRestrictedClientFields(body, ["provider_sku", "unit_price", "provider", "billing_cycle"]);
+    const payload = validateBasePayload(body);
+    await assertCatalogAllowlist(payload);
+    return jsonResponse({ ok: true, quoteAccepted: true }, 200, request);
+  } catch (e) {
+    return jsonResponse({ error: e instanceof Error ? e.message : "Invalid request." }, 422, request);
+  }
+});


### PR DESCRIPTION
### Motivation
- Ensure provider edge functions accept only well-formed requests for `planCode`, `region`, `service_type`, and `idempotencyKey` to avoid invalid or harmful provider calls.
- Enforce server-side allowlist checks against the active `service_catalog` so clients cannot request unsupported plans/regions/service types.
- Prevent clients from supplying fields that can change billing or provider behavior outside catalog definitions.
- Add per-user quotas/rate limits and record actor identity + request fingerprint for an audit trail in `provision_events`.

### Description
- Add a shared guard module `supabase/functions/_shared/provider-guard.ts` implementing `validateBasePayload`, `assertCatalogAllowlist`, `assertQuota`, `rejectRestrictedClientFields`, `fingerprintRequest`, the `BasePayload` interface, and `ServiceAction` type, plus regex-based validation for `planCode`, `region`, and `idempotencyKey`.
- Add `supabase/functions/provider-quote/index.ts` which enforces auth, rejects restricted client fields, validates payload shape via `validateBasePayload`, and checks the active `service_catalog` allowlist before accepting a quote.
- Add `supabase/functions/provider-provision/index.ts` which enforces auth, rejects restricted fields, validates payload, checks the catalog allowlist, enforces per-user quotas for resources and provision jobs, and inserts an audit event into `provision_events` containing `user_id`, `actor_id`, `actor_type`, `request_fingerprint`, `action`, and `metadata`.
- Add `supabase/functions/provider-lifecycle/index.ts` which validates lifecycle `action` against an allowlist, rejects restricted fields, validates payload, enforces per-user lifecycle rate limiting, and records the lifecycle action in `provision_events` with actor and request fingerprint.

### Testing
- Ran `npm test`, which executed the repository test suite; the run failed due to pre-existing unrelated failures in `shared/payments/catalog.test.js` (2 failing tests), so the overall test run is failing but failures are not caused by these provider function changes.
- Attempted to run `deno fmt` for the new Deno edge functions but the `deno` binary is not available in the environment, so formatting could not be validated here.
- No unit tests were added for the new provider functions in this change set; smoke checks are limited to the above automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40863ef3c832bb6bc09baed996519)