### PR TITLE
Add reseller order orchestration, paid-order provisioning guards, and migration

### DIFF
--- a/supabase/functions/provider-provision/index.ts
+++ b/supabase/functions/provider-provision/index.ts
@@ -1,0 +1,48 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient } from "../_shared/supabase.ts";
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  const adminClient = createAdminClient();
+
+  try {
+    const body = await request.json();
+    const orderItemId = String(body?.orderItemId || "");
+    const provider = String(body?.provider || "");
+    const payload = body?.payload || {};
+
+    if (!orderItemId) return jsonResponse({ error: "orderItemId is required." }, 422, request);
+    if (!provider) return jsonResponse({ error: "provider is required." }, 422, request);
+
+    const { data: orderItem, error: orderItemError } = await adminClient
+      .from("order_items")
+      .select("id, order_id, orders!inner(id, status)")
+      .eq("id", orderItemId)
+      .single();
+
+    if (orderItemError || !orderItem) {
+      return jsonResponse({ error: "Order item not found.", details: orderItemError?.message }, 404, request);
+    }
+
+    const orderStatus = (orderItem as any).orders?.status;
+    if (orderStatus !== "paid") {
+      return jsonResponse({ error: "Provisioning requires a paid order." }, 409, request);
+    }
+
+    const { data, error } = await adminClient
+      .from("provider_provision_queue")
+      .insert({ order_item_id: orderItemId, provider, payload, status: "queued" })
+      .select("id")
+      .single();
+
+    if (error || !data) {
+      return jsonResponse({ error: "Failed to enqueue provisioning.", details: error?.message }, 500, request);
+    }
+
+    return jsonResponse({ queueId: data.id, status: "queued" }, 200, request);
+  } catch (error) {
+    return jsonResponse({ error: error instanceof Error ? error.message : "Unknown error." }, 500, request);
+  }
+});

--- a/supabase/functions/start-reseller-order/index.ts
+++ b/supabase/functions/start-reseller-order/index.ts
@@ -1,0 +1,106 @@
+import { buildInvoice, buildPaymentHash, parseCreatePaymentResponse } from "../../../shared/payments/safepay-server.js";
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+
+const gatewayUrl = Deno.env.get("SAFEPAY_GATEWAY_URL") || "https://www.safepayto.me/new/gateway/";
+const ALLOWED_PLANS = new Set(["starter", "growth", "scale"]);
+const ALLOWED_REGIONS = new Set(["us-east", "us-west", "eu-central", "ap-south"]);
+
+function requiredEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  try {
+    const authHeader = request.headers.get("Authorization");
+    const userClient = createUserClient(authHeader);
+    const adminClient = createAdminClient();
+
+    const { data: { user }, error: userError } = await userClient.auth.getUser();
+    if (userError || !user) return jsonResponse({ error: "You must be signed in." }, 401, request);
+
+    const body = await request.json();
+    const plan = String(body?.plan || "").toLowerCase();
+    const region = String(body?.region || "").toLowerCase();
+    const amountMinor = Number(body?.amountMinor);
+    const currency = String(body?.currency || "USD").toUpperCase();
+
+    if (!ALLOWED_PLANS.has(plan)) return jsonResponse({ error: "Unsupported plan." }, 422, request);
+    if (!ALLOWED_REGIONS.has(region)) return jsonResponse({ error: "Unsupported region." }, 422, request);
+    if (!Number.isInteger(amountMinor) || amountMinor <= 0) return jsonResponse({ error: "Invalid amountMinor." }, 422, request);
+
+    const merchantId = requiredEnv("SAFEPAY_MERCHANT_ID");
+    const merchantSecret = requiredEnv("SAFEPAY_MERCHANT_SECRET");
+    const invoice = buildInvoice({ prefix: "RSL", userId: user.id });
+    const description = `Reseller order (${plan} in ${region})`;
+
+    const payload = new URLSearchParams({
+      _cmd: "payment",
+      merchant_id: merchantId,
+      amount: String(amountMinor),
+      currency,
+      invoice,
+      language: "ENG",
+      cl_fname: String(body?.customer?.firstName || "Reseller"),
+      cl_lname: String(body?.customer?.lastName || "Customer"),
+      cl_email: String(body?.customer?.email || user.email || ""),
+      cl_phone: String(body?.customer?.phone || "000000000"),
+      cl_country: String(body?.customer?.countryCode || "US"),
+      cl_city: String(body?.customer?.city || "Unknown"),
+      description,
+      psys: "",
+      get_trans: "1",
+      hash: buildPaymentHash({ amountMinor, currency, merchantId, merchantSecret }),
+    });
+
+    const providerResponse = await fetch(gatewayUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: payload,
+    });
+    const providerText = await providerResponse.text();
+    if (!providerResponse.ok) return jsonResponse({ error: "Failed to create payment session.", details: providerText }, 502, request);
+
+    const { checkoutUrl, providerTransactionId } = parseCreatePaymentResponse(providerText, {
+      allowedHosts: [new URL(gatewayUrl).hostname, "www.safepayto.me", "safepayto.me"],
+    });
+
+    const { data: order, error: orderError } = await adminClient
+      .from("orders")
+      .insert({
+        user_id: user.id,
+        invoice,
+        amount_minor: amountMinor,
+        currency,
+        status: "pending_payment",
+        provider_transaction_id: providerTransactionId,
+      })
+      .select("id")
+      .single();
+
+    if (orderError || !order) return jsonResponse({ error: "Could not create order.", details: orderError?.message }, 500, request);
+
+    const { data: orderItem, error: itemError } = await adminClient
+      .from("order_items")
+      .insert({
+        order_id: order.id,
+        plan_code: plan,
+        region_code: region,
+        quantity: 1,
+        unit_amount_minor: amountMinor,
+      })
+      .select("id")
+      .single();
+
+    if (itemError || !orderItem) return jsonResponse({ error: "Could not create order item.", details: itemError?.message }, 500, request);
+
+    return jsonResponse({ orderId: order.id, orderItemId: orderItem.id, checkoutUrl, invoice }, 200, request);
+  } catch (error) {
+    return jsonResponse({ error: error instanceof Error ? error.message : "Unknown error." }, 500, request);
+  }
+});

--- a/supabase/migrations/20260501090000_reseller_order_orchestration.rollback.sql
+++ b/supabase/migrations/20260501090000_reseller_order_orchestration.rollback.sql
@@ -1,0 +1,14 @@
+begin;
+
+drop trigger if exists service_resources_requires_paid_order on public.service_resources;
+drop function if exists public.ensure_paid_order_item_for_service_resource();
+
+alter table public.service_resources
+  alter column order_item_id drop not null;
+
+drop table if exists public.provider_provision_queue;
+drop table if exists public.service_resources;
+drop table if exists public.order_items;
+drop table if exists public.orders;
+
+commit;

--- a/supabase/migrations/20260501090000_reseller_order_orchestration.smoke.sql
+++ b/supabase/migrations/20260501090000_reseller_order_orchestration.smoke.sql
@@ -1,0 +1,28 @@
+-- smoke: create pending order + item, verify provisioning gate fails and paid gate succeeds
+
+with new_order as (
+  insert into public.orders (user_id, invoice, amount_minor, currency, status)
+  values (auth.uid(), 'SMOKE-RSL-1', 1000, 'USD', 'pending_payment')
+  returning id
+), new_item as (
+  insert into public.order_items (order_id, plan_code, region_code, quantity, unit_amount_minor)
+  select id, 'starter', 'us-east', 1, 1000 from new_order
+  returning id
+)
+select id from new_item;
+
+-- should fail until order status becomes paid
+insert into public.service_resources (order_item_id, user_id, provider)
+select oi.id, auth.uid(), 'smoke-provider'
+from public.order_items oi
+join public.orders o on o.id = oi.order_id
+where o.invoice = 'SMOKE-RSL-1';
+
+update public.orders set status = 'paid' where invoice = 'SMOKE-RSL-1';
+
+-- should now pass
+insert into public.service_resources (order_item_id, user_id, provider)
+select oi.id, auth.uid(), 'smoke-provider'
+from public.order_items oi
+join public.orders o on o.id = oi.order_id
+where o.invoice = 'SMOKE-RSL-1';

--- a/supabase/migrations/20260501090000_reseller_order_orchestration.sql
+++ b/supabase/migrations/20260501090000_reseller_order_orchestration.sql
@@ -1,0 +1,81 @@
+begin;
+
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  invoice text not null unique,
+  amount_minor integer not null check (amount_minor > 0),
+  currency text not null,
+  status text not null default 'pending_payment' check (status in ('pending_payment','paid','failed','cancelled')),
+  provider_transaction_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.order_items (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  plan_code text not null,
+  region_code text not null,
+  quantity integer not null default 1 check (quantity > 0),
+  unit_amount_minor integer not null check (unit_amount_minor > 0),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.provider_provision_queue (
+  id bigserial primary key,
+  order_item_id uuid not null references public.order_items(id) on delete restrict,
+  provider text not null,
+  payload jsonb not null default '{}'::jsonb,
+  status text not null default 'queued' check (status in ('queued','processing','done','failed')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.service_resources (
+  id uuid primary key default gen_random_uuid(),
+  order_item_id uuid,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider text not null,
+  resource_ref text,
+  created_at timestamptz not null default now()
+);
+
+-- prevent service resources from being created without paid order linkage
+create or replace function public.ensure_paid_order_item_for_service_resource()
+returns trigger
+language plpgsql
+as $$
+declare
+  current_order_status text;
+begin
+  if new.order_item_id is null then
+    raise exception 'service_resources.order_item_id is required';
+  end if;
+
+  select o.status
+  into current_order_status
+  from public.order_items oi
+  join public.orders o on o.id = oi.order_id
+  where oi.id = new.order_item_id;
+
+  if current_order_status is distinct from 'paid' then
+    raise exception 'service_resources requires a paid order item';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists service_resources_requires_paid_order on public.service_resources;
+create trigger service_resources_requires_paid_order
+before insert or update on public.service_resources
+for each row execute function public.ensure_paid_order_item_for_service_resource();
+
+-- remove direct-null path once orchestration is live
+alter table public.service_resources
+  alter column order_item_id set not null;
+
+create index if not exists order_items_order_id_idx on public.order_items(order_id);
+create index if not exists orders_user_status_idx on public.orders(user_id, status, created_at desc);
+
+commit;


### PR DESCRIPTION
### Motivation
- Introduce a single orchestration entrypoint for reseller orders that validates plan/region, creates order records, and returns a payment session so provisioning can be gated behind paid orders.
- Prevent accidental creation of `service_resources` without a paid order linkage and remove the previous nullable/direct-null path once orchestration is live.
- Provide safe rollout tooling with an explicit rollback script and a smoke SQL script to validate the gating behaviour during deployment.

### Description
- Add a new Edge Function `start-reseller-order` at `supabase/functions/start-reseller-order/index.ts` which validates `plan`/`region`, creates rows in `orders` and `order_items`, initiates a payment session with the gateway, and returns `checkoutUrl`, `invoice`, and created IDs.
- Update the `provider-provision` function at `supabase/functions/provider-provision/index.ts` to require that the `order_items` row is linked to an `orders` row with status `paid` before inserting into `provider_provision_queue`.
- Add migration `supabase/migrations/20260501090000_reseller_order_orchestration.sql` which creates `orders`, `order_items`, `provider_provision_queue`, and `service_resources`, installs trigger/function `ensure_paid_order_item_for_service_resource()` to block `service_resources` creation unless the linked order item is `paid`, and sets `service_resources.order_item_id` to `NOT NULL`.
- Add companion files: rollback script `supabase/migrations/20260501090000_reseller_order_orchestration.rollback.sql` to safely revert schema changes and smoke script `supabase/migrations/20260501090000_reseller_order_orchestration.smoke.sql` that demonstrates the expected fail-before-pay and succeed-after-pay sequence.

### Testing
- Ran repository checks `git diff --check` and `git status --short`, and both checks completed successfully.
- Included `supabase/migrations/20260501090000_reseller_order_orchestration.smoke.sql` as an automated smoke test to be executed against a staging DB to verify that `service_resources` inserts fail while order status is `pending_payment` and succeed after updating to `paid`.
- No live database migration was executed during this rollout; schema changes are provided as migration files and should be applied in a controlled deployment and validated with the included smoke SQL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f409e889ec832bb5e9d24b82b96752)