### PR TITLE
Provider orchestration: deploy, lifecycle actions, live sync, and failure UI

### DIFF
--- a/src/context/DashboardContext.jsx
+++ b/src/context/DashboardContext.jsx
@@ -3,59 +3,43 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useMemo,
 	useState,
 } from "react";
 import { supabase } from "../lib/supabaseClient";
 import { useAuth } from "./AuthContext";
 
 const DashboardContext = createContext();
-
-const initialResources = []; // Empty by default as per user request
-
+const initialResources = [];
 const initialTransactions = [];
-
 const defaultPlan = { name: "Pro Plan", credits: 2900, price: 29 };
+
+const callJsonFunction = async (name, payload) => {
+	const { data, error } = await supabase.functions.invoke(name, {
+		body: payload,
+	});
+	if (error) throw error;
+	return data;
+};
 
 export function DashboardProvider({ children }) {
 	const { user } = useAuth();
+	const [resources, setResources] = useState(() => JSON.parse(localStorage.getItem("wys_resources") || "[]"));
+	const [transactions, setTransactions] = useState(() => JSON.parse(localStorage.getItem("wys_transactions") || "[]"));
+	const [currentPlan, setCurrentPlan] = useState(() => JSON.parse(localStorage.getItem("wys_plan") || JSON.stringify(defaultPlan)));
+	const [resourceJobs, setResourceJobs] = useState({});
 
-	const [resources, setResources] = useState(() => {
-		const saved = localStorage.getItem("wys_resources");
-		return saved ? JSON.parse(saved) : initialResources;
-	});
-
-	const [transactions, setTransactions] = useState(() => {
-		const saved = localStorage.getItem("wys_transactions");
-		return saved ? JSON.parse(saved) : initialTransactions;
-	});
-
-	const [currentPlan, setCurrentPlan] = useState(() => {
-		const saved = localStorage.getItem("wys_plan");
-		return saved ? JSON.parse(saved) : defaultPlan;
-	});
-
-	// Calculate balance from transactions
-	const balance = transactions.reduce((sum, tx) => sum + tx.amount, 0);
+	const balance = useMemo(() => transactions.reduce((sum, tx) => sum + tx.amount, 0), [transactions]);
 
 	const loadTransactions = useCallback(async () => {
-		if (!user) {
-			return;
-		}
-
+		if (!user) return;
 		const { data, error } = await supabase
 			.from("credit_transactions")
-			.select(
-				"id, description, amount, type, status, currency_paid, currency, created_at",
-			)
+			.select("id, description, amount, type, status, currency_paid, currency, created_at")
 			.eq("user_id", user.id)
 			.order("created_at", { ascending: false });
-
-		if (error) {
-			console.warn("Unable to load credit transactions from Supabase.", error);
-			return;
-		}
-
-		const mapped = (data || []).map((tx) => ({
+		if (error) return;
+		setTransactions((data || []).map((tx) => ({
 			id: `tx_${tx.id}`,
 			date: new Date(tx.created_at).toISOString().split("T")[0],
 			description: tx.description,
@@ -64,9 +48,7 @@ export function DashboardProvider({ children }) {
 			type: tx.type,
 			currencyPaid: tx.currency_paid || "-",
 			currency: tx.currency || null,
-		}));
-
-		setTransactions(mapped);
+		})));
 	}, [user]);
 
 	useEffect(() => {
@@ -79,53 +61,94 @@ export function DashboardProvider({ children }) {
 		loadTransactions();
 	}, [loadTransactions]);
 
-	const changePlan = (plan) => {
-		setCurrentPlan(plan);
-	};
+	const pushJobEvent = useCallback((resourceId, message, state = "info") => {
+		setResourceJobs((prev) => {
+			const existing = prev[resourceId] || [];
+			return {
+				...prev,
+				[resourceId]: [{ at: new Date().toISOString(), message, state }, ...existing].slice(0, 25),
+			};
+		});
+	}, []);
 
-	const addResource = (resource) => {
-		const newResource = {
-			...resource,
-			id: Math.random().toString(36).substr(2, 9),
-			status: "Running", // Default to running
-			uptime: "Just now",
-			ip: `10.0.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}`,
+	const runResourceSync = useCallback(async (resourceId) => {
+		const syncData = await callJsonFunction("provider-sync-status", { resourceId });
+		setResources((prev) => prev.map((res) => (res.id === resourceId ? { ...res, ...syncData } : res)));
+		if (syncData?.timelineEntry) {
+			pushJobEvent(resourceId, syncData.timelineEntry.message, syncData.timelineEntry.state);
+		}
+		return syncData;
+	}, [pushJobEvent]);
+
+	useEffect(() => {
+		if (resources.length === 0) return;
+		const timer = setInterval(() => {
+			for (const res of resources) {
+				runResourceSync(res.id).catch(() => {});
+			}
+		}, 15000);
+		return () => clearInterval(timer);
+	}, [resources, runResourceSync]);
+
+	const deployResource = useCallback(async ({ typeInfo, region }) => {
+		if (!user) throw new Error("Not authenticated");
+		const optimisticId = crypto.randomUUID();
+		const baseResource = {
+			id: optimisticId,
+			name: `${typeInfo.id}-${Math.random().toString(36).slice(2, 7)}`,
+			type: typeInfo.typeName,
+			region,
+			price: typeInfo.price,
+			status: "Provisioning",
+			ip: "pending",
 		};
-		setResources((prev) => [newResource, ...prev]);
-	};
+		setResources((prev) => [baseResource, ...prev]);
+		pushJobEvent(optimisticId, "Deployment queued", "pending");
 
-	const removeResource = (id) => {
-		setResources((prev) => prev.filter((r) => r.id !== id));
-	};
-
-	const deductCredits = useCallback(
-		async (description, amount) => {
-			if (!user) throw new Error("Not authenticated");
-			const { error } = await supabase.from("credit_transactions").insert({
-				user_id: user.id,
-				description,
-				amount: -Math.abs(amount),
-				type: "debit",
-				status: "completed",
+		try {
+			pushJobEvent(optimisticId, "Creating payment record", "running");
+			const payment = await callJsonFunction("create-payment-session", {
+				amount: typeInfo.cost,
+				description: `${typeInfo.typeName} deployment`,
 			});
-			if (error) throw error;
+			pushJobEvent(optimisticId, "Payment authorized", "success");
+
+			const lifecycle = await callJsonFunction("provider-lifecycle", {
+				action: "deploy",
+				resource: baseResource,
+				payment,
+			});
+			setResources((prev) => prev.map((r) => (r.id === optimisticId ? { ...r, ...lifecycle.resource, status: lifecycle.resource?.status || "Running" } : r)));
+			pushJobEvent(optimisticId, "Resource deployed", "success");
 			await loadTransactions();
-		},
-		[user, loadTransactions],
-	);
+		} catch (error) {
+			setResources((prev) => prev.map((r) => (r.id === optimisticId ? { ...r, status: "Failed", lastError: error.message || "Deployment failed" } : r)));
+			pushJobEvent(optimisticId, error.message || "Deployment failed", "failed");
+			throw error;
+		}
+	}, [loadTransactions, pushJobEvent, user]);
+
+	const mutateResourceLifecycle = useCallback(async (resourceId, action) => {
+		pushJobEvent(resourceId, `${action} requested`, "running");
+		const data = await callJsonFunction("provider-lifecycle", { action, resourceId });
+		setResources((prev) => prev.filter((res) => !(action === "delete" && res.id === resourceId)).map((res) => (res.id === resourceId ? { ...res, ...data.resource, status: data.resource?.status || res.status } : res)));
+		pushJobEvent(resourceId, `${action} completed`, "success");
+		return data;
+	}, [pushJobEvent]);
 
 	return (
 		<DashboardContext.Provider
 			value={{
 				resources,
+				resourceJobs,
 				balance,
 				transactions,
 				currentPlan,
-				addResource,
-				removeResource,
-				deductCredits,
 				refreshTransactions: loadTransactions,
-				changePlan,
+				changePlan: setCurrentPlan,
+				deployResource,
+				mutateResourceLifecycle,
+				runResourceSync,
 			}}
 		>
 			{children}

--- a/src/pages/dashboard/NewService.jsx
+++ b/src/pages/dashboard/NewService.jsx
@@ -20,7 +20,7 @@ const regions = [
 
 export default function NewService() {
     const navigate = useNavigate()
-    const { addResource, balance, deductCredits } = useDashboard()
+    const { deployResource, balance } = useDashboard()
     const [selectedType, setSelectedType] = useState(serviceTypes[0].id)
     const [selectedRegion, setSelectedRegion] = useState(regions[0].id)
     const [isDeploying, setIsDeploying] = useState(false)
@@ -37,16 +37,10 @@ export default function NewService() {
         setDeployError('')
 
         try {
-            await deductCredits(`${selectedTypeInfo.typeName} deployment`, selectedTypeInfo.cost)
-            addResource({
-                name: `${selectedTypeInfo.id}-${Math.random().toString(36).substr(2, 5)}`,
-                type: selectedTypeInfo.typeName,
-                region: regionInfo.id,
-                price: selectedTypeInfo.price
-            })
+            await deployResource({ typeInfo: selectedTypeInfo, region: regionInfo.id })
             navigate('/dashboard')
-        } catch {
-            setDeployError('Failed to deduct credits. Please try again.')
+        } catch (error) {
+            setDeployError(error?.message || 'Deployment failed. Please retry or contact support.')
         } finally {
             setIsDeploying(false)
         }

--- a/src/pages/dashboard/ResourceList.jsx
+++ b/src/pages/dashboard/ResourceList.jsx
@@ -1,75 +1,95 @@
-import { motion } from 'framer-motion'
-import { Link } from 'react-router-dom'
-import { useDashboard } from '../../context/DashboardContext'
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import { useDashboard } from "../../context/DashboardContext";
+
+const statusClass = {
+	Running: "bg-green-500 text-green-400",
+	Provisioning: "bg-blue-500 text-blue-400",
+	Suspended: "bg-amber-500 text-amber-400",
+	Failed: "bg-red-500 text-red-400",
+};
 
 export default function ResourceList({ typeFilter, title }) {
-    const { resources } = useDashboard()
+	const { resources, resourceJobs, mutateResourceLifecycle, runResourceSync } = useDashboard();
+	const [busy, setBusy] = useState({});
+	const [errorMap, setErrorMap] = useState({});
 
-    const filteredResources = typeFilter
-        ? resources.filter(r => r.type.toLowerCase().includes(typeFilter.toLowerCase()))
-        : resources
+	const filteredResources = typeFilter
+		? resources.filter((r) => r.type.toLowerCase().includes(typeFilter.toLowerCase()))
+		: resources;
 
-    return (
-        <>
-            <div className="flex justify-between items-end mb-10">
-                <div>
-                    <h1 className="text-3xl font-bold mb-2">{title}</h1>
-                    <p className="text-slate-400">Manage your {title.toLowerCase()} and deployments.</p>
-                </div>
-                <Link to="/dashboard/new" className="bg-cyan-600 hover:bg-cyan-500 text-white px-6 py-3 rounded-xl font-bold transition-all shadow-lg hover:shadow-cyan-500/25 flex items-center gap-2">
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                    </svg>
-                    New Resource
-                </Link>
-            </div>
+	const runAction = async (resourceId, action) => {
+		setBusy((prev) => ({ ...prev, [`${resourceId}:${action}`]: true }));
+		setErrorMap((prev) => ({ ...prev, [resourceId]: "" }));
+		try {
+			if (action === "sync") await runResourceSync(resourceId);
+			else await mutateResourceLifecycle(resourceId, action);
+		} catch (error) {
+			setErrorMap((prev) => ({ ...prev, [resourceId]: error?.message || "Action failed" }));
+		} finally {
+			setBusy((prev) => ({ ...prev, [`${resourceId}:${action}`]: false }));
+		}
+	};
 
-            <div className="bg-[#0f1629] border border-white/5 rounded-2xl overflow-hidden">
-                {filteredResources.length === 0 ? (
-                    <div className="p-12 text-center text-slate-400">
-                        <div className="w-16 h-16 bg-white/5 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <svg className="w-8 h-8 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M12 5l7 7-7 7" />
-                            </svg>
-                        </div>
-                        <h3 className="text-lg font-medium text-white mb-2">No {title.toLowerCase()} found</h3>
-                        <p className="mb-6">You don't have any {title.toLowerCase()} in this region.</p>
-                        <Link to="/dashboard/new" className="text-cyan-400 hover:text-cyan-300 font-medium">Deploy Now &rarr;</Link>
-                    </div>
-                ) : (
-                    <div className="overflow-x-auto">
-                        <table className="w-full text-left text-sm">
-                            <thead className="bg-white/5 text-slate-400">
-                                <tr>
-                                    <th className="p-4 font-medium pl-6">Name</th>
-                                    <th className="p-4 font-medium">Region</th>
-                                    <th className="p-4 font-medium">IP Address</th>
-                                    <th className="p-4 font-medium">Status</th>
-                                    <th className="p-4 font-medium text-right pr-6">Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-white/5">
-                                {filteredResources.map((res) => (
-                                    <tr key={res.id} className="hover:bg-white/5 transition-colors">
-                                        <td className="p-4 pl-6 font-medium text-white">{res.name}</td>
-                                        <td className="p-4 text-slate-400">{res.region}</td>
-                                        <td className="p-4 text-slate-400 font-mono text-xs">{res.ip}</td>
-                                        <td className="p-4">
-                                            <div className="flex items-center gap-2">
-                                                <span className="w-2 h-2 rounded-full bg-green-500"></span>
-                                                <span className="text-green-400">{res.status}</span>
-                                            </div>
-                                        </td>
-                                        <td className="p-4 text-right pr-6">
-                                            <button className="text-cyan-400 hover:text-cyan-300">Manage</button>
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                )}
-            </div>
-        </>
-    )
+	return (
+		<>
+			<div className="flex justify-between items-end mb-10">
+				<div>
+					<h1 className="text-3xl font-bold mb-2">{title}</h1>
+					<p className="text-slate-400">Manage your {title.toLowerCase()} and deployments.</p>
+				</div>
+				<Link to="/dashboard/new" className="bg-cyan-600 hover:bg-cyan-500 text-white px-6 py-3 rounded-xl font-bold transition-all shadow-lg hover:shadow-cyan-500/25 flex items-center gap-2">New Resource</Link>
+			</div>
+
+			<div className="bg-[#0f1629] border border-white/5 rounded-2xl overflow-hidden">
+				{filteredResources.length === 0 ? (
+					<div className="p-12 text-center text-slate-400">No {title.toLowerCase()} found.</div>
+				) : (
+					<div className="overflow-x-auto">
+						<table className="w-full text-left text-sm">
+							<thead className="bg-white/5 text-slate-400">
+								<tr>
+									<th className="p-4 font-medium pl-6">Name</th><th className="p-4 font-medium">Region</th><th className="p-4 font-medium">IP Address</th><th className="p-4 font-medium">Status</th><th className="p-4 font-medium text-right pr-6">Actions</th>
+								</tr>
+							</thead>
+							<tbody className="divide-y divide-white/5">
+								{filteredResources.map((res) => (
+									<React.Fragment key={res.id}>
+										<tr key={res.id} className="hover:bg-white/5 transition-colors align-top">
+											<td className="p-4 pl-6 font-medium text-white">{res.name}</td>
+											<td className="p-4 text-slate-400">{res.region}</td>
+											<td className="p-4 text-slate-400 font-mono text-xs">{res.ip || "pending"}</td>
+											<td className="p-4"><div className="flex items-center gap-2"><span className={`w-2 h-2 rounded-full ${(statusClass[res.status] || "bg-slate-400 text-slate-300").split(" ")[0]}`}></span><span className={(statusClass[res.status] || "text-slate-300").split(" ")[1]}>{res.status}</span></div></td>
+											<td className="p-4 pr-6">
+												<div className="flex flex-wrap justify-end gap-2">
+													<button onClick={() => runAction(res.id, "sync")} disabled={busy[`${res.id}:sync`]} className="text-cyan-400 hover:text-cyan-300 disabled:opacity-50">Sync now</button>
+													<button onClick={() => runAction(res.id, "suspend")} disabled={busy[`${res.id}:suspend`] || res.status === "Suspended"} className="text-amber-400 hover:text-amber-300 disabled:opacity-50">Suspend</button>
+													<button onClick={() => runAction(res.id, "resume")} disabled={busy[`${res.id}:resume`] || res.status === "Running"} className="text-green-400 hover:text-green-300 disabled:opacity-50">Resume</button>
+													<button onClick={() => runAction(res.id, "delete")} disabled={busy[`${res.id}:delete`]} className="text-red-400 hover:text-red-300 disabled:opacity-50">Delete</button>
+												</div>
+											</td>
+										</tr>
+										<tr className="bg-black/10">
+											<td colSpan={5} className="px-6 py-3 text-xs text-slate-300">
+												<div className="mb-2 font-semibold">Job timeline</div>
+												{(resourceJobs[res.id] || []).length === 0 ? <div className="text-slate-500">No jobs yet.</div> : (resourceJobs[res.id] || []).slice(0, 5).map((job) => <div key={`${job.at}:${job.message}`} className="mb-1">{new Date(job.at).toLocaleString()} · {job.message}</div>)}
+												{(res.status === "Failed" || errorMap[res.id]) && (
+													<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-3 rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-red-300">
+														<div className="font-medium">Action failed</div>
+														<div className="text-red-200/90">{errorMap[res.id] || res.lastError || "Provider returned an error."}</div>
+														<div className="mt-2 flex gap-3"><button className="underline" onClick={() => runAction(res.id, "sync")}>Retry sync</button><Link to="/support" className="underline">Contact support</Link></div>
+													</motion.div>
+												)}
+											</td>
+										</tr>
+									</React.Fragment>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+		</>
+	);
 }


### PR DESCRIPTION
### Motivation
- Replace the local optimistic-only deploy path with a real orchestration + payment flow and add per-resource lifecycle controls, live sync/polling, job timeline, and failure UI so resource operations are provider-driven and observable.

### Description
- Add orchestration helpers and APIs to `src/context/DashboardContext.jsx`: `callJsonFunction`, `deployResource` (calls `create-payment-session` then `provider-lifecycle`), `mutateResourceLifecycle`, `runResourceSync`, a 15s polling loop, and `resourceJobs` timeline state; deployments record timeline events and failures (`status: Failed`, `lastError`).
- Update `src/pages/dashboard/NewService.jsx` to use the new `deployResource` orchestration API instead of local `addResource` + `deductCredits` logic.
- Replace `src/pages/dashboard/ResourceList.jsx` UI/actions to include `Sync now`, `Suspend`, `Resume`, and `Delete` wired to provider APIs, show a per-resource job timeline, and render a failure panel with retry and support affordances.
- Preserve transaction-loading and local persistence behavior (`localStorage` for resources/transactions/plan) while surfacing live provider state.

### Testing
- Executed `npm run build` (Vite build) which completed successfully.
- Executed `npm run lint` which reported pre-existing repository-wide Biome/formatting/config diagnostics unrelated to these changes and did not pass.
- No new unit tests were added and existing test suite was not modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40a01ef10832baebce4db52f13798)