### PR TITLE
Harden edge function payload validation, allowlists, rate-limits, and audit trail

### DIFF
--- a/supabase/functions/_shared/security.ts
+++ b/supabase/functions/_shared/security.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import { createAdminClient } from "./supabase.ts";
+
+const PLAN_ALLOWLIST = new Set(["starter", "pro", "business", "enterprise"]);
+const REGION_ALLOWLIST = new Set(["us-east", "eu-west", "ap-south"]);
+const SERVICE_TYPE_ALLOWLIST = new Set([
+	"vps",
+	"k8s",
+	"gpu",
+	"database",
+	"gameserver",
+]);
+
+const REQUIRED_ENV = [
+	"SAFEPAY_MERCHANT_ID",
+	"SAFEPAY_MERCHANT_SECRET",
+	"RESEND_API_KEY",
+	"SECRET_ROTATION_CHECKLIST_ACK",
+	"SAFEPAY_MERCHANT_SECRET_VERSION",
+	"RESEND_API_KEY_VERSION",
+] as const;
+
+for (const envName of REQUIRED_ENV) {
+	if (!Deno.env.get(envName)) {
+		throw new Error(`Startup env validation failed: missing ${envName}`);
+	}
+}
+
+if (Deno.env.get("SECRET_ROTATION_CHECKLIST_ACK") !== "true") {
+	throw new Error(
+		"Startup env validation failed: SECRET_ROTATION_CHECKLIST_ACK must be true.",
+	);
+}
+
+export function readJson<T>(value: unknown, fallback: T): T {
+	if (typeof value !== "object" || value === null) return fallback;
+	return value as T;
+}
+
+export function enforceCatalogAllowlist(payload: Record<string, unknown>) {
+	const plan = String(payload.plan ?? "")
+		.trim()
+		.toLowerCase();
+	const region = String(payload.region ?? "")
+		.trim()
+		.toLowerCase();
+	const serviceType = String(payload.serviceType ?? "")
+		.trim()
+		.toLowerCase();
+
+	if (plan && !PLAN_ALLOWLIST.has(plan))
+		throw new Error("Plan is not allowed.");
+	if (region && !REGION_ALLOWLIST.has(region))
+		throw new Error("Region is not allowed.");
+	if (serviceType && !SERVICE_TYPE_ALLOWLIST.has(serviceType))
+		throw new Error("Service type is not allowed.");
+}
+
+export function requestMeta(request: Request) {
+	const requestId = request.headers.get("x-request-id") || crypto.randomUUID();
+	const ip =
+		request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+	const userAgent = request.headers.get("user-agent") ?? "unknown";
+	return {
+		requestId,
+		ipHash: createHash("sha256").update(ip).digest("hex"),
+		userAgentHash: createHash("sha256").update(userAgent).digest("hex"),
+	};
+}
+
+export async function enforceRateLimit(
+	userId: string,
+	action: string,
+	requestId: string,
+	perHour: number,
+	perDay: number,
+) {
+	const admin = createAdminClient();
+	const hourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+	const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+	const [{ count: hourCount, error: hErr }, { count: dayCount, error: dErr }] =
+		await Promise.all([
+			admin
+				.from("function_rate_limits")
+				.select("id", { count: "exact", head: true })
+				.eq("user_id", userId)
+				.eq("action", action)
+				.gte("created_at", hourAgo),
+			admin
+				.from("function_rate_limits")
+				.select("id", { count: "exact", head: true })
+				.eq("user_id", userId)
+				.eq("action", action)
+				.gte("created_at", dayAgo),
+		]);
+
+	if (hErr || dErr) throw new Error("Unable to enforce rate limits.");
+	if ((hourCount ?? 0) >= perHour || (dayCount ?? 0) >= perDay)
+		throw new Error("Rate limit exceeded for this action.");
+
+	const { error: insertErr } = await admin
+		.from("function_rate_limits")
+		.insert({ user_id: userId, action, request_id: requestId });
+	if (insertErr && insertErr.code !== "23505")
+		throw new Error("Unable to persist rate limit state.");
+}
+
+export async function writeAuditTrail(args: {
+	userId?: string;
+	action: string;
+	actor: string;
+	requestId: string;
+	ipHash: string;
+	userAgentHash: string;
+	payload?: unknown;
+}) {
+	const admin = createAdminClient();
+	await admin.from("function_audit_trail").insert({
+		user_id: args.userId ?? null,
+		action: args.action,
+		actor: args.actor,
+		request_id: args.requestId,
+		ip_hash: args.ipHash,
+		user_agent_hash: args.userAgentHash,
+		payload: args.payload ?? null,
+	});
+}

--- a/supabase/functions/contact-form/index.ts
+++ b/supabase/functions/contact-form/index.ts
@@ -1,5 +1,11 @@
 import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
 import { MAIL_FROM, MAIL_TO, sendEmail } from "../_shared/mailer.ts";
+import {
+	enforceCatalogAllowlist,
+	readJson,
+	requestMeta,
+	writeAuditTrail,
+} from "../_shared/security.ts";
 
 Deno.serve(async (request) => {
 	if (request.method === "OPTIONS") {
@@ -11,7 +17,9 @@ Deno.serve(async (request) => {
 	}
 
 	try {
-		const body = await request.json();
+		const body = readJson<Record<string, unknown>>(await request.json(), {});
+		enforceCatalogAllowlist(body);
+		const meta = requestMeta(request);
 		const firstName = String(body?.firstName || "").trim();
 		const lastName = String(body?.lastName || "").trim();
 		const email = String(body?.email || "").trim();
@@ -46,6 +54,14 @@ Deno.serve(async (request) => {
 			`,
 		});
 
+		await writeAuditTrail({
+			action: "contact-form",
+			actor: email || "anonymous",
+			requestId: meta.requestId,
+			ipHash: meta.ipHash,
+			userAgentHash: meta.userAgentHash,
+			payload: { email, company },
+		});
 		return jsonResponse({ ok: true }, 200, request);
 	} catch (error) {
 		return jsonResponse(

--- a/supabase/functions/create-payment-session/index.ts
+++ b/supabase/functions/create-payment-session/index.ts
@@ -13,6 +13,13 @@ import {
 	parseCreatePaymentResponse,
 } from "../../../shared/payments/safepay-server.js";
 import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+	enforceCatalogAllowlist,
+	enforceRateLimit,
+	readJson,
+	requestMeta,
+	writeAuditTrail,
+} from "../_shared/security.ts";
 import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
 
 const gatewayUrl =
@@ -56,7 +63,16 @@ Deno.serve(async (request) => {
 			);
 		}
 
-		const body = await request.json();
+		const body = readJson<Record<string, unknown>>(await request.json(), {});
+		enforceCatalogAllowlist(body);
+		const meta = requestMeta(request);
+		await enforceRateLimit(
+			user.id,
+			"create-payment-session",
+			meta.requestId,
+			20,
+			200,
+		);
 		const currency = String(body?.currency || "").toUpperCase();
 		const merchantId = requiredEnv("SAFEPAY_MERCHANT_ID");
 		const merchantSecret = requiredEnv("SAFEPAY_MERCHANT_SECRET");
@@ -98,13 +114,14 @@ Deno.serve(async (request) => {
 			);
 		}
 
+		const customer = readJson<Record<string, unknown>>(body?.customer, {});
 		const normalizedCustomer = normalizeCustomerProfile({
-			firstName: body?.customer?.firstName || existingProfile?.first_name,
-			lastName: body?.customer?.lastName || existingProfile?.last_name,
+			firstName: customer?.firstName || existingProfile?.first_name,
+			lastName: customer?.lastName || existingProfile?.last_name,
 			email: user.email || existingProfile?.email,
-			phone: body?.customer?.phone || existingProfile?.phone,
-			countryCode: body?.customer?.countryCode || existingProfile?.country_code,
-			city: body?.customer?.city || existingProfile?.city,
+			phone: customer?.phone || existingProfile?.phone,
+			countryCode: customer?.countryCode || existingProfile?.country_code,
+			city: customer?.city || existingProfile?.city,
 		});
 		const missingFields = getMissingCustomerFields(normalizedCustomer);
 
@@ -245,6 +262,16 @@ Deno.serve(async (request) => {
 				request,
 			);
 		}
+
+		await writeAuditTrail({
+			userId: user.id,
+			action: "create-payment-session",
+			actor: user.email || user.id,
+			requestId: meta.requestId,
+			ipHash: meta.ipHash,
+			userAgentHash: meta.userAgentHash,
+			payload: { invoice, amountMinor, currency },
+		});
 
 		return jsonResponse(
 			{

--- a/supabase/functions/refresh-payment-status/index.ts
+++ b/supabase/functions/refresh-payment-status/index.ts
@@ -3,6 +3,13 @@ import { summarizeRefreshResult } from "../../../shared/payments/reconciliation.
 import { buildRequestHash } from "../../../shared/payments/safepay-server.js";
 import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
 import { MAIL_FROM, MAIL_TO, sendEmail } from "../_shared/mailer.ts";
+import {
+	enforceCatalogAllowlist,
+	enforceRateLimit,
+	readJson,
+	requestMeta,
+	writeAuditTrail,
+} from "../_shared/security.ts";
 import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
 
 const gatewayUrl =
@@ -51,7 +58,16 @@ Deno.serve(async (request) => {
 			);
 		}
 
-		const body = await request.json();
+		const body = readJson<Record<string, unknown>>(await request.json(), {});
+		enforceCatalogAllowlist(body);
+		const meta = requestMeta(request);
+		await enforceRateLimit(
+			user.id,
+			"refresh-payment-status",
+			meta.requestId,
+			60,
+			500,
+		);
 		const invoice = String(body?.invoice || "").trim();
 
 		if (!invoice) {
@@ -247,6 +263,15 @@ Deno.serve(async (request) => {
 			}
 		}
 
+		await writeAuditTrail({
+			userId: user.id,
+			action: "refresh-payment-status",
+			actor: user.email || user.id,
+			requestId: meta.requestId,
+			ipHash: meta.ipHash,
+			userAgentHash: meta.userAgentHash,
+			payload: { invoice, status: refreshSummary.status },
+		});
 		return jsonResponse(
 			{
 				invoice,

--- a/supabase/migrations/20260501100000_edge_function_security_controls.sql
+++ b/supabase/migrations/20260501100000_edge_function_security_controls.sql
@@ -1,0 +1,35 @@
+begin;
+
+create table if not exists public.function_rate_limits (
+  id bigserial primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  action text not null,
+  request_id text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists function_rate_limits_user_action_created_idx
+  on public.function_rate_limits (user_id, action, created_at desc);
+
+create unique index if not exists function_rate_limits_request_id_key
+  on public.function_rate_limits (request_id);
+
+create table if not exists public.function_audit_trail (
+  id bigserial primary key,
+  user_id uuid references auth.users(id) on delete set null,
+  action text not null,
+  actor text not null,
+  request_id text not null,
+  ip_hash text,
+  user_agent_hash text,
+  payload jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists function_audit_trail_user_created_idx
+  on public.function_audit_trail (user_id, created_at desc);
+
+create index if not exists function_audit_trail_action_created_idx
+  on public.function_audit_trail (action, created_at desc);
+
+commit;


### PR DESCRIPTION
### Motivation
- Prevent malformed or unsafe edge function payloads by adding strict server-side parsing and validation for all incoming requests to edge functions.
- Ensure that catalog fields cannot be abused by enforcing allowlists for `plan`, `region`, and `serviceType` values.
- Limit abusive/frequent operations by adding per-user rate limits/quotas for create/lifecycle calls and persist idempotent request tracking.
- Provide an audit trail with non-sensitive metadata and enforce a secret-rotation acknowledgement at startup to reduce operational risk.

### Description
- Added a new shared helper `supabase/functions/_shared/security.ts` that exposes `readJson`, `enforceCatalogAllowlist`, `requestMeta`, `enforceRateLimit`, and `writeAuditTrail`, and performs a startup env validation gate (requires `SECRET_ROTATION_CHECKLIST_ACK=true` and secret version env vars).
- Applied the shared security helpers to `create-payment-session`, `refresh-payment-status`, and `contact-form` edge functions to use parsed payloads (`readJson`), allowlist checks, request metadata hashing (`requestId`, `ipHash`, `userAgentHash`), per-user rate limits (`create-payment-session`: 20/hr, 200/day; `refresh-payment-status`: 60/hr, 500/day), and audit writes.
- Added an SQL migration `supabase/migrations/20260501100000_edge_function_security_controls.sql` which creates `function_rate_limits` and `function_audit_trail` tables and indexes to persist rate-limit events and audit records.
- The catalog allowlists are defined in `security.ts` for `plan`, `region`, and `serviceType` and will reject unknown values when present; audit records store `actor`, `request_id`, `ip_hash`, `user_agent_hash`, and a JSON `payload`.

### Testing
- Ran `npx biome format --write` to format the changed files and `npx biome check` scoped to the modified functions and shared helper (`supabase/functions/_shared/security.ts`, `supabase/functions/create-payment-session/index.ts`, `supabase/functions/refresh-payment-status/index.ts`, `supabase/functions/contact-form/index.ts`) which completed successfully.
- Observed that `npm run lint` fails with many pre-existing repo-wide Biome issues (configuration/schema mismatch and unrelated formatting diagnostics) which are not introduced by these changes.
- Added and validated the migration file presence (`supabase/migrations/20260501100000_edge_function_security_controls.sql`) and ensured function code calls the new helpers; no runtime integration tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40a048884832bbab941e6d1cbae9e)