### PR TITLE
Add reseller order checkout lane and paid-gated provisioning

### DIFF
--- a/src/lib/paymentGateway.js
+++ b/src/lib/paymentGateway.js
@@ -29,3 +29,14 @@ export async function refreshPaymentStatus(payload) {
 		"Unable to refresh payment status right now.",
 	);
 }
+
+export async function startResellerOrder(payload) {
+	const response = await supabase.functions.invoke("start-reseller-order", {
+		body: payload,
+	});
+
+	return unwrapFunctionResponse(
+		response,
+		"Unable to create reseller order right now.",
+	);
+}

--- a/src/pages/dashboard/NewService.jsx
+++ b/src/pages/dashboard/NewService.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { useDashboard } from '../../context/DashboardContext'
+import { startResellerOrder } from '../../lib/paymentGateway'
 
 const serviceTypes = [
     { id: 'vps', name: 'Virtual Private Server', icon: 'server', description: 'High-performance NVMe VPS', price: '100 credits/mo', cost: 100, typeName: 'VPS (Standard)' },
@@ -20,7 +21,7 @@ const regions = [
 
 export default function NewService() {
     const navigate = useNavigate()
-    const { addResource, balance, deductCredits } = useDashboard()
+    const { balance } = useDashboard()
     const [selectedType, setSelectedType] = useState(serviceTypes[0].id)
     const [selectedRegion, setSelectedRegion] = useState(regions[0].id)
     const [isDeploying, setIsDeploying] = useState(false)
@@ -37,16 +38,13 @@ export default function NewService() {
         setDeployError('')
 
         try {
-            await deductCredits(`${selectedTypeInfo.typeName} deployment`, selectedTypeInfo.cost)
-            addResource({
-                name: `${selectedTypeInfo.id}-${Math.random().toString(36).substr(2, 5)}`,
-                type: selectedTypeInfo.typeName,
-                region: regionInfo.id,
-                price: selectedTypeInfo.price
+            const session = await startResellerOrder({
+                sku: selectedTypeInfo.id,
+                region: regionInfo.id
             })
-            navigate('/dashboard')
+            navigate(`/dashboard/billing?paymentId=${session.paymentOrderId}`)
         } catch {
-            setDeployError('Failed to deduct credits. Please try again.')
+            setDeployError('Failed to start checkout. Please try again.')
         } finally {
             setIsDeploying(false)
         }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -379,6 +379,12 @@ verify_jwt = false
 [functions.refresh-payment-status]
 verify_jwt = false
 
+[functions.start-reseller-order]
+verify_jwt = false
+
+[functions.provider-provision]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/provider-provision/index.ts
+++ b/supabase/functions/provider-provision/index.ts
@@ -1,0 +1,47 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient } from "../_shared/supabase.ts";
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+	if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+	try {
+		const adminClient = createAdminClient();
+		const body = await request.json();
+		const orderId = String(body?.orderId || "");
+		if (!orderId) return jsonResponse({ error: "orderId is required." }, 422, request);
+
+		const { data: order, error: orderError } = await adminClient
+			.from("orders")
+			.select("id, user_id, state, payment_order_id, order_items(id, sku, region)")
+			.eq("id", orderId)
+			.single();
+		if (orderError || !order) return jsonResponse({ error: "Order not found." }, 404, request);
+		if (order.state !== "paid") return jsonResponse({ error: "Order is not paid." }, 409, request);
+
+		const item = order.order_items?.[0];
+		if (!item) return jsonResponse({ error: "Order has no items." }, 409, request);
+
+		const { data: resource, error: resourceError } = await adminClient.from("service_resources").insert({
+			user_id: order.user_id,
+			order_item_id: item.id,
+			sku: item.sku,
+			region: item.region,
+			status: "queued",
+		}).select("id").single();
+		if (resourceError || !resource) return jsonResponse({ error: "Unable to create service resource.", details: resourceError?.message }, 500, request);
+
+		const { error: jobError } = await adminClient.from("provision_jobs").insert({
+			order_id: order.id,
+			order_item_id: item.id,
+			service_resource_id: resource.id,
+			status: "queued",
+		});
+		if (jobError) return jsonResponse({ error: "Unable to enqueue provision job.", details: jobError.message }, 500, request);
+
+		await adminClient.from("orders").update({ state: "provisioning" }).eq("id", order.id);
+		return jsonResponse({ ok: true, serviceResourceId: resource.id }, 200, request);
+	} catch (error) {
+		return jsonResponse({ error: error instanceof Error ? error.message : "Unknown error." }, 500, request);
+	}
+});

--- a/supabase/functions/refresh-payment-status/index.ts
+++ b/supabase/functions/refresh-payment-status/index.ts
@@ -61,7 +61,7 @@ Deno.serve(async (request) => {
 		const { data: order, error: orderError } = await adminClient
 			.from("payment_orders")
 			.select(
-				"id, user_id, invoice, amount_minor, currency, credits_to_add, status, provider_transaction_id, completed_at",
+				"id, user_id, invoice, amount_minor, currency, credits_to_add, status, provider_transaction_id, completed_at, external_reference",
 			)
 			.eq("invoice", invoice)
 			.maybeSingle();
@@ -194,6 +194,23 @@ Deno.serve(async (request) => {
 				500,
 				request,
 			);
+		}
+
+		if (refreshSummary.status === "completed" && order.external_reference) {
+			await adminClient
+				.from("orders")
+				.update({ state: "paid" })
+				.eq("id", order.external_reference)
+				.in("state", ["pending_payment", "payment_processing"]);
+
+			await fetch(`${Deno.env.get("SUPABASE_URL")}/functions/v1/provider-provision`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")}`,
+				},
+				body: JSON.stringify({ orderId: order.external_reference }),
+			});
 		}
 
 		let creditsApplied = Boolean(existingCredit);

--- a/supabase/functions/start-reseller-order/index.ts
+++ b/supabase/functions/start-reseller-order/index.ts
@@ -1,0 +1,64 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+
+const SKU_PRICING: Record<string, { amount_minor: number; currency: string; description: string }> = {
+	vps: { amount_minor: 10000, currency: "USD", description: "VPS (Standard)" },
+	k8s: { amount_minor: 100000, currency: "USD", description: "Kubernetes (Managed)" },
+	db: { amount_minor: 30000, currency: "USD", description: "Database (PG/MySQL)" },
+	gpu: { amount_minor: 5000, currency: "USD", description: "GPU (H100)" },
+};
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+	if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+	try {
+		const authHeader = request.headers.get("Authorization");
+		const userClient = createUserClient(authHeader);
+		const adminClient = createAdminClient();
+		const { data: { user }, error: userError } = await userClient.auth.getUser();
+		if (userError || !user) return jsonResponse({ error: "You must be signed in." }, 401, request);
+
+		const body = await request.json();
+		const sku = String(body?.sku || "").toLowerCase();
+		const region = String(body?.region || "").trim();
+		const pricing = SKU_PRICING[sku];
+		if (!pricing || !region) return jsonResponse({ error: "Invalid sku or region." }, 422, request);
+
+		const { data: order, error: orderError } = await adminClient.from("orders").insert({
+			user_id: user.id,
+			state: "pending_payment",
+			amount_minor: pricing.amount_minor,
+			currency: pricing.currency,
+		}).select("id").single();
+		if (orderError || !order) return jsonResponse({ error: "Unable to create order.", details: orderError?.message }, 500, request);
+
+		const { data: orderItem, error: itemError } = await adminClient.from("order_items").insert({
+			order_id: order.id,
+			sku,
+			region,
+			description: pricing.description,
+			amount_minor: pricing.amount_minor,
+		}).select("id").single();
+		if (itemError || !orderItem) return jsonResponse({ error: "Unable to create order item.", details: itemError?.message }, 500, request);
+
+		const { data: payment, error: paymentError } = await adminClient.from("payment_orders").insert({
+			user_id: user.id,
+			invoice: `RSL-${order.id}`,
+			amount_minor: pricing.amount_minor,
+			currency: pricing.currency,
+			credits_to_add: 0,
+			status: "processing",
+			description: `Reseller order for ${pricing.description} (${region})`,
+			external_reference: order.id,
+		}).select("id").single();
+		if (paymentError || !payment) return jsonResponse({ error: "Unable to create payment session.", details: paymentError?.message }, 500, request);
+
+		const { error: orderLinkError } = await adminClient.from("orders").update({ payment_order_id: payment.id }).eq("id", order.id);
+		if (orderLinkError) return jsonResponse({ error: "Unable to link payment order.", details: orderLinkError.message }, 500, request);
+
+		return jsonResponse({ orderId: order.id, orderItemId: orderItem.id, paymentOrderId: payment.id, checkoutUrl: `/dashboard/billing?paymentId=${payment.id}` }, 200, request);
+	} catch (error) {
+		return jsonResponse({ error: error instanceof Error ? error.message : "Unknown error." }, 500, request);
+	}
+});

--- a/supabase/migrations/20260501120000_reseller_order_lane.sql
+++ b/supabase/migrations/20260501120000_reseller_order_lane.sql
@@ -1,0 +1,49 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  payment_order_id uuid references public.payment_orders(id) on delete set null,
+  state text not null default 'pending_payment',
+  amount_minor integer not null,
+  currency text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.order_items (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  sku text not null,
+  region text not null,
+  description text,
+  amount_minor integer not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.service_resources (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  order_item_id uuid not null references public.order_items(id) on delete restrict,
+  sku text not null,
+  region text not null,
+  status text not null default 'queued',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.provision_jobs (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  order_item_id uuid not null references public.order_items(id) on delete restrict,
+  service_resource_id uuid not null references public.service_resources(id) on delete cascade,
+  status text not null default 'queued',
+  created_at timestamptz not null default now()
+);
+
+alter table public.payment_orders add column if not exists external_reference uuid;
+alter table public.service_resources alter column order_item_id set not null;
+
+grant select, insert, update on table public.orders to service_role;
+grant select, insert, update on table public.order_items to service_role;
+grant select, insert, update on table public.service_resources to service_role;
+grant select, insert, update on table public.provision_jobs to service_role;


### PR DESCRIPTION
### Motivation
- Move deployment/payment flow server-side so resources are not created in the browser and provisioning only happens after a confirmed payment. 
- Introduce an order/order_item abstraction to represent reseller purchases and link them to payment sessions via `payment_orders.external_reference`.
- Enforce paid-state checks before any provider-side resource creation and restore the temporary nullable `order_item_id` to `NOT NULL` for data integrity.

### Description
- Add `start-reseller-order` edge function that creates `orders` and `order_items`, inserts a `payment_orders` record with `external_reference`, and returns checkout identifiers; implemented at `supabase/functions/start-reseller-order/index.ts`.
- Add `provider-provision` edge function that enforces `order.state === "paid"` before creating `service_resources` and inserting `provision_jobs`; implemented at `supabase/functions/provider-provision/index.ts`.
- Extend `refresh-payment-status` to select `external_reference`, mark linked reseller `orders` as paid when the payment is completed, and trigger server-side provisioning by invoking `provider-provision`; modified at `supabase/functions/refresh-payment-status/index.ts`.
- Update client to use the new server flow by adding `startResellerOrder` in `src/lib/paymentGateway.js` and calling it from `src/pages/dashboard/NewService.jsx` instead of creating resources client-side.
- Add a migration `supabase/migrations/20260501120000_reseller_order_lane.sql` to create `orders`, `order_items`, `service_resources`, and `provision_jobs`, add `payment_orders.external_reference`, and set `service_resources.order_item_id` back to `NOT NULL`.
- Register the new functions in `supabase/config.toml` (`[functions.start-reseller-order]` and `[functions.provider-provision]`).

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite emitted a chunk-size warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40ae6385c832bbc1f38552c78e527)