### PR TITLE
Provisioning queue: atomic claim, retry classification, events, and admin requeue endpoint

### DIFF
--- a/supabase/functions/requeue-dead-letter/index.ts
+++ b/supabase/functions/requeue-dead-letter/index.ts
@@ -1,0 +1,101 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+
+Deno.serve(async (request) => {
+	if (request.method === "OPTIONS") {
+		return new Response("ok", { headers: getCorsHeaders(request) });
+	}
+
+	if (request.method !== "POST") {
+		return jsonResponse({ error: "Method not allowed." }, 405, request);
+	}
+
+	try {
+		const authHeader = request.headers.get("Authorization");
+		const userClient = createUserClient(authHeader);
+		const adminClient = createAdminClient();
+
+		const {
+			data: { user },
+			error: userError,
+		} = await userClient.auth.getUser();
+
+		if (userError || !user) {
+			return jsonResponse({ error: "Unauthorized." }, 401, request);
+		}
+
+		const { data: adminRole, error: roleError } = await adminClient
+			.from("user_roles")
+			.select("role")
+			.eq("user_id", user.id)
+			.eq("role", "admin")
+			.maybeSingle();
+
+		if (roleError || !adminRole) {
+			return jsonResponse({ error: "Admin access required." }, 403, request);
+		}
+
+		const body = await request.json();
+		const jobId = String(body?.jobId || "").trim();
+
+		if (!jobId) {
+			return jsonResponse({ error: "jobId is required." }, 400, request);
+		}
+
+		const { data: job, error: jobError } = await adminClient
+			.from("provision_jobs")
+			.select("id, status, attempts, max_attempts")
+			.eq("id", jobId)
+			.maybeSingle();
+
+		if (jobError || !job) {
+			return jsonResponse({ error: "Job not found." }, 404, request);
+		}
+
+		if (job.status !== "dead_letter") {
+			return jsonResponse({ error: "Only dead-letter jobs can be requeued." }, 409, request);
+		}
+
+		const { data: updatedJob, error: updateError } = await adminClient
+			.from("provision_jobs")
+			.update({
+				status: "queued",
+				locked_at: null,
+				locked_by: null,
+				available_at: new Date().toISOString(),
+				finished_at: null,
+				attempts: Math.min(job.attempts, Math.max(job.max_attempts - 1, 0)),
+			})
+			.eq("id", jobId)
+			.eq("status", "dead_letter")
+			.select("id, status, attempts, max_attempts")
+			.maybeSingle();
+
+		if (updateError || !updatedJob) {
+			return jsonResponse(
+				{ error: "Unable to requeue job.", details: updateError?.message },
+				500,
+				request,
+			);
+		}
+
+		await adminClient.from("provision_events").insert({
+			job_id: updatedJob.id,
+			event_type: "job.requeued",
+			message: "Dead-letter job requeued by admin",
+			metadata: {
+				requeued_by: user.id,
+				previous_attempts: job.attempts,
+				new_attempts: updatedJob.attempts,
+			},
+		});
+
+		return jsonResponse({ job: updatedJob }, 200, request);
+	} catch (error) {
+		return jsonResponse(
+			{ error: "Failed to requeue dead-letter job.", details: error instanceof Error ? error.message : String(error) },
+			500,
+			request,
+		);
+	}
+});

--- a/supabase/migrations/20260501120000_provisioning_queue_reliability.sql
+++ b/supabase/migrations/20260501120000_provisioning_queue_reliability.sql
@@ -1,0 +1,177 @@
+create table if not exists public.provision_jobs (
+  id uuid primary key default gen_random_uuid(),
+  resource_type text not null,
+  payload jsonb not null default '{}'::jsonb,
+  status text not null default 'queued' check (status in ('queued','processing','succeeded','failed','dead_letter')),
+  attempts integer not null default 0,
+  max_attempts integer not null default 5 check (max_attempts > 0),
+  last_error text,
+  error_class text,
+  provider_request_id text,
+  available_at timestamptz not null default now(),
+  locked_at timestamptz,
+  locked_by text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists provision_jobs_claim_idx on public.provision_jobs (status, available_at, locked_at);
+
+create table if not exists public.provision_events (
+  id bigint generated always as identity primary key,
+  job_id uuid not null references public.provision_jobs(id) on delete cascade,
+  event_type text not null,
+  message text,
+  metadata jsonb not null default '{}'::jsonb,
+  provider_request_id text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists provision_events_job_id_created_at_idx on public.provision_events (job_id, created_at desc);
+
+create or replace function public.set_provision_jobs_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_provision_jobs_updated_at on public.provision_jobs;
+create trigger set_provision_jobs_updated_at
+before update on public.provision_jobs
+for each row execute function public.set_provision_jobs_updated_at();
+
+create or replace function public.classify_provision_error(error_code text, error_message text)
+returns text
+language plpgsql
+as $$
+begin
+  if error_code in ('ETIMEDOUT','ECONNRESET','EAI_AGAIN','429','500','502','503','504') then
+    return 'transient';
+  end if;
+
+  if coalesce(error_message,'') ilike any (array['%timeout%','%temporar%','%rate limit%','%try again%']) then
+    return 'transient';
+  end if;
+
+  return 'terminal';
+end;
+$$;
+
+create or replace function public.claim_provision_job(lock_timeout_seconds integer default 300, worker_id text default null)
+returns public.provision_jobs
+language plpgsql
+security definer
+as $$
+declare
+  claimed public.provision_jobs;
+begin
+  with candidate as (
+    select id
+    from public.provision_jobs
+    where status = 'queued'
+      and available_at <= now()
+      and (locked_at is null or locked_at < now() - make_interval(secs => lock_timeout_seconds))
+    order by created_at
+    for update skip locked
+    limit 1
+  )
+  update public.provision_jobs j
+  set status = 'processing',
+      locked_at = now(),
+      locked_by = coalesce(worker_id, current_setting('request.jwt.claim.sub', true), 'worker'),
+      started_at = coalesce(j.started_at, now())
+  from candidate
+  where j.id = candidate.id
+    and j.status = 'queued'
+  returning j.* into claimed;
+
+  return claimed;
+end;
+$$;
+
+create or replace function public.finish_provision_job(
+  p_job_id uuid,
+  p_success boolean,
+  p_error_code text default null,
+  p_error_message text default null,
+  p_provider_request_id text default null
+)
+returns public.provision_jobs
+language plpgsql
+security definer
+as $$
+declare
+  updated_job public.provision_jobs;
+  next_error_class text;
+  next_status text;
+  next_attempts integer;
+begin
+  if p_success then
+    update public.provision_jobs
+    set status = 'succeeded',
+        locked_at = null,
+        locked_by = null,
+        finished_at = now(),
+        provider_request_id = coalesce(p_provider_request_id, provider_request_id),
+        error_class = null,
+        last_error = null
+    where id = p_job_id and status = 'processing'
+    returning * into updated_job;
+
+    if updated_job.id is null then
+      raise exception 'Job % is not in processing state', p_job_id;
+    end if;
+
+    insert into public.provision_events (job_id, event_type, message, metadata, provider_request_id)
+    values (updated_job.id, 'job.succeeded', 'Provisioning job completed', jsonb_build_object('attempts', updated_job.attempts), updated_job.provider_request_id);
+
+    return updated_job;
+  end if;
+
+  next_error_class := public.classify_provision_error(p_error_code, p_error_message);
+
+  update public.provision_jobs
+  set attempts = attempts + 1,
+      error_class = next_error_class,
+      last_error = coalesce(p_error_message, p_error_code, 'unknown error'),
+      provider_request_id = coalesce(p_provider_request_id, provider_request_id)
+  where id = p_job_id and status = 'processing'
+  returning attempts, max_attempts into next_attempts, updated_job.max_attempts;
+
+  if next_attempts is null then
+    raise exception 'Job % is not in processing state', p_job_id;
+  end if;
+
+  next_status := case
+    when next_error_class = 'terminal' then 'failed'
+    when next_attempts >= updated_job.max_attempts then 'dead_letter'
+    else 'queued'
+  end;
+
+  update public.provision_jobs
+  set status = next_status,
+      locked_at = null,
+      locked_by = null,
+      finished_at = case when next_status in ('failed','dead_letter') then now() else finished_at end,
+      available_at = case when next_status = 'queued' then now() + (interval '15 seconds' * greatest(next_attempts, 1)) else available_at end
+  where id = p_job_id
+  returning * into updated_job;
+
+  insert into public.provision_events (job_id, event_type, message, metadata, provider_request_id)
+  values (
+    updated_job.id,
+    case when next_status = 'dead_letter' then 'job.dead_letter' when next_status='queued' then 'job.retry_scheduled' else 'job.failed' end,
+    coalesce(p_error_message, 'Provisioning job failed'),
+    jsonb_build_object('error_code', p_error_code, 'error_class', next_error_class, 'attempts', updated_job.attempts, 'max_attempts', updated_job.max_attempts),
+    updated_job.provider_request_id
+  );
+
+  return updated_job;
+end;
+$$;


### PR DESCRIPTION
### Motivation
- Prevent double execution of provisioning jobs by introducing an atomic claim path from `queued -> processing`.
- Recover stuck workers by adding lock timeout semantics to allow stale `locked_at` recovery.
- Classify retries as transient vs terminal and only dead-letter after exhausting attempts for transient failures to avoid premature DLQing.
- Improve observability by recording structured lifecycle events and provider request IDs, and provide a safe admin path to requeue DLQ jobs.

### Description
- Add `supabase/migrations/20260501120000_provisioning_queue_reliability.sql` which creates `provision_jobs` and `provision_events` tables and a trigger to update `updated_at`.
- Implement `public.claim_provision_job(...)` as an atomic guarded claim using `FOR UPDATE SKIP LOCKED` and a `locked_at` staleness window to recover timed-out locks.
- Add `public.classify_provision_error(...)` to categorize errors as `transient` or `terminal` and `public.finish_provision_job(...)` to increment attempts, apply backoff, transition to `dead_letter` only when `attempts >= max_attempts` for transient errors, and emit structured events (including `provider_request_id`).
- Add Edge Function `supabase/functions/requeue-dead-letter/index.ts` which enforces authenticated admin access, only allows requeueing `dead_letter` jobs with a status-guarded update, adjusts `attempts`, clears locks, sets `available_at`, and writes a `job.requeued` event.

### Testing
- Ran `deno fmt --check supabase/functions/requeue-dead-letter/index.ts supabase/migrations/20260501120000_provisioning_queue_reliability.sql`, which failed because `deno` is not installed in the environment.
- No other automated test suites were executed against the new SQL migration or the Edge Function in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40af5a5b4832ba1c82f0bb494f1f8)