### PR TITLE
Add Admin Observability: queue/failure metrics, feature flags, reconciliation and runbooks

### DIFF
--- a/docs/runbooks/observability-incident-runbooks.md
+++ b/docs/runbooks/observability-incident-runbooks.md
@@ -1,0 +1,21 @@
+# Observability Incident Runbooks
+
+## Retry
+1. Confirm provider health recovered.
+2. Requeue failed jobs from dead-letter queue.
+3. Monitor error rate for 15 minutes.
+
+## Rollback
+1. Toggle off impacted `service_feature_flags` rows.
+2. Roll back provider routing to last stable profile.
+3. Verify no new failures fire.
+
+## Orphan cleanup
+1. Run `run_daily_paid_provision_reconciliation()`.
+2. Export mismatches from `daily_reconciliation_runs.details`.
+3. Trigger repair provisioning for paid-but-unprovisioned records.
+
+## Provider outage mode
+1. Set all affected regions to rollout 0%.
+2. Accept requests into queue-only mode.
+3. Communicate degraded SLA and continue periodic reconciliation.

--- a/src/pages/dashboard/AdminObservability.jsx
+++ b/src/pages/dashboard/AdminObservability.jsx
@@ -117,6 +117,9 @@ export default function AdminObservability() {
 	const [profiles, setProfiles] = useState([]);
 	const [roles, setRoles] = useState([]);
 	const [transactions, setTransactions] = useState([]);
+	const [alerts, setAlerts] = useState([]);
+	const [featureFlags, setFeatureFlags] = useState([]);
+	const [reconRuns, setReconRuns] = useState([]);
 
 	// Filter / pagination state
 	const [dateRange, setDateRange] = useState("all");
@@ -135,7 +138,7 @@ export default function AdminObservability() {
 		}
 		setLoading(true);
 		setError("");
-		const [profilesRes, rolesRes, txRes] = await Promise.all([
+		const [profilesRes, rolesRes, txRes, alertsRes, flagsRes, reconRes] = await Promise.all([
 			supabase
 				.from("profiles")
 				.select("id, email, created_at")
@@ -149,12 +152,18 @@ export default function AdminObservability() {
 				.select("id, user_id, description, amount, type, status, created_at")
 				.order("created_at", { ascending: false })
 				.limit(300),
+			supabase.from("observability_alert_events").select("id, alert_type, severity, status, value, threshold, context, created_at").order("created_at", { ascending: false }).limit(100),
+			supabase.from("service_feature_flags").select("id, service_type, region, enabled, rollout_percent, notes, updated_at").order("updated_at", { ascending: false }).limit(100),
+			supabase.from("daily_reconciliation_runs").select("id, run_date, paid_count, provisioned_count, mismatch_count, status, details, created_at").order("run_date", { ascending: false }).limit(30),
 		]);
-		if (profilesRes.error || rolesRes.error || txRes.error) {
+		if (profilesRes.error || rolesRes.error || txRes.error || alertsRes.error || flagsRes.error || reconRes.error) {
 			setError(
 				profilesRes.error?.message ||
 					rolesRes.error?.message ||
 					txRes.error?.message ||
+					alertsRes.error?.message ||
+					flagsRes.error?.message ||
+					reconRes.error?.message ||
 					"Unable to load backoffice observability data.",
 			);
 			setLoading(false);
@@ -163,6 +172,9 @@ export default function AdminObservability() {
 		setProfiles(profilesRes.data || []);
 		setRoles(rolesRes.data || []);
 		setTransactions(txRes.data || []);
+		setAlerts(alertsRes.data || []);
+		setFeatureFlags(flagsRes.data || []);
+		setReconRuns(reconRes.data || []);
 		setLoading(false);
 	}, [isAdmin, adminLoading]);
 
@@ -225,6 +237,11 @@ export default function AdminObservability() {
 	const suspiciousEvents = transactions.filter(
 		(tx) => (tx.status || "Completed") !== "Completed",
 	).length;
+
+	const queueDepth = alerts.filter((a) => a.alert_type === "dead_letter_growth").reduce((max, a) => Math.max(max, Number(a.value || 0)), 0);
+	const providerFailures = alerts.filter((a) => a.alert_type === "provider_api_failure_spike").reduce((sum, a) => sum + Number(a.value || 0), 0);
+	const paymentProvisionMismatches = reconRuns[0]?.mismatch_count || 0;
+	const enabledFlags = featureFlags.filter((f) => f.enabled).length;
 
 	// ─── Cashflow series (6 months) ──────────────────────────────────────────────
 
@@ -612,6 +629,34 @@ export default function AdminObservability() {
 							</div>
 						</div>
 					</div>
+				</div>
+			</div>
+
+
+			{/* Queue + Failure Metrics */}
+			<div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h2 className="font-bold text-lg mb-1">Queue Health</h2><p className="text-3xl font-black text-amber-300">{queueDepth.toLocaleString()}</p>
+				</div>
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h2 className="font-bold text-lg mb-1">Provider API Failures</h2><p className="text-3xl font-black text-red-400">{providerFailures.toLocaleString()}</p>
+				</div>
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h2 className="font-bold text-lg mb-1">Payment/Provision Drift</h2>
+					<p className={`text-3xl font-black ${paymentProvisionMismatches > 0 ? "text-red-400" : "text-emerald-300"}`}>{paymentProvisionMismatches.toLocaleString()}</p>
+				</div>
+			</div>
+			<div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h3 className="font-bold text-lg mb-3">Alert Policies</h3>
+					<ul className="space-y-2 text-sm">{["dead_letter_growth", "provider_api_failure_spike", "payment_provision_mismatch"].map((type) => { const hit = alerts.find((a) => a.alert_type === type); return <li key={type} className="flex items-center justify-between border border-white/5 rounded-lg px-3 py-2"><span className="text-slate-300">{type}</span><span className={hit && hit.status !== "ok" ? "text-red-400" : "text-emerald-300"}>{hit?.status || "ok"}</span></li>; })}</ul>
+				</div>
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h3 className="font-bold text-lg mb-1">Feature Flags</h3><p className="text-2xl font-bold text-cyan-300 mb-3">{enabledFlags}/{featureFlags.length} enabled</p>
+				</div>
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h3 className="font-bold text-lg mb-3">Incident Runbooks</h3>
+					<ul className="space-y-2 text-xs text-slate-300"><li className="border border-white/5 rounded-lg px-3 py-2"><strong>Retry:</strong> replay failed jobs.</li><li className="border border-white/5 rounded-lg px-3 py-2"><strong>Rollback:</strong> disable impacted feature flags.</li><li className="border border-white/5 rounded-lg px-3 py-2"><strong>Orphan cleanup:</strong> reconcile paid rows without provision.</li><li className="border border-white/5 rounded-lg px-3 py-2"><strong>Provider outage mode:</strong> queue acceptance and defer provisioning.</li></ul>
 				</div>
 			</div>
 

--- a/supabase/migrations/20260501100000_observability_ops.sql
+++ b/supabase/migrations/20260501100000_observability_ops.sql
@@ -1,0 +1,67 @@
+create table if not exists public.observability_alert_events (
+  id bigint generated always as identity primary key,
+  alert_type text not null,
+  severity text not null default 'warning',
+  status text not null default 'ok',
+  value numeric not null default 0,
+  threshold numeric,
+  context jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.service_feature_flags (
+  id bigint generated always as identity primary key,
+  service_type text not null,
+  region text not null,
+  enabled boolean not null default false,
+  rollout_percent int not null default 0 check (rollout_percent between 0 and 100),
+  notes text,
+  updated_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique (service_type, region)
+);
+
+create table if not exists public.daily_reconciliation_runs (
+  id bigint generated always as identity primary key,
+  run_date date not null unique,
+  paid_count int not null default 0,
+  provisioned_count int not null default 0,
+  mismatch_count int not null default 0,
+  status text not null default 'ok',
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create or replace function public.run_daily_paid_provision_reconciliation()
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  paid_total int := 0;
+  provisioned_total int := 0;
+  mismatch_total int := 0;
+begin
+  select count(*) into paid_total from public.credit_transactions where type = 'credit' and status = 'Completed';
+  select count(*) into provisioned_total from public.credit_transactions where type = 'debit' and status = 'Completed';
+  mismatch_total := greatest(abs(paid_total - provisioned_total), 0);
+
+  insert into public.daily_reconciliation_runs(run_date, paid_count, provisioned_count, mismatch_count, status, details)
+  values (
+    current_date,
+    paid_total,
+    provisioned_total,
+    mismatch_total,
+    case when mismatch_total > 0 then 'mismatch' else 'ok' end,
+    jsonb_build_object('generated_by', 'run_daily_paid_provision_reconciliation')
+  )
+  on conflict (run_date)
+  do update set
+    paid_count = excluded.paid_count,
+    provisioned_count = excluded.provisioned_count,
+    mismatch_count = excluded.mismatch_count,
+    status = excluded.status,
+    details = excluded.details,
+    created_at = now();
+end;
+$$;


### PR DESCRIPTION
### Motivation
- Provide operators a unified Admin Observability surface to spot queue/back-end failures and provider issues quickly.
- Surface payment vs provision drift and make daily reconciliation results available for triage.
- Add feature-flag controls scoped by service type and region to enable phased rollouts and safe rollbacks.
- Ship concise incident runbooks to standardize operational actions for retry, rollback, orphan cleanup, and provider outage mode.

### Description
- Update `src/pages/dashboard/AdminObservability.jsx` to load alert events, feature flags, and reconciliation runs and to render panels for queue depth, provider API failure spikes, payment/provision drift, alert policy status, feature-flag snapshot, and incident runbooks.
- Add a Supabase migration `supabase/migrations/20260501100000_observability_ops.sql` that creates `observability_alert_events`, `service_feature_flags`, and `daily_reconciliation_runs`, and implements `run_daily_paid_provision_reconciliation()` to capture paid vs provisioned counts.
- Add operator documentation `docs/runbooks/observability-incident-runbooks.md` containing retry, rollback, orphan cleanup, and provider outage mode runbooks.
- The reconciliation logic persists daily mismatches to `daily_reconciliation_runs` so UI and operators can surface and act on drift.

### Testing
- Ran a production build with `npm run build`, which completed successfully (Vite build produced the production bundle).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40afeeea4832bac544cf47871dc1d)