### PR TITLE
Add reseller-order flow and enforce paid-state provisioning

### DIFF
--- a/src/pages/dashboard/NewService.jsx
+++ b/src/pages/dashboard/NewService.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { useDashboard } from '../../context/DashboardContext'
+import { supabase } from '../../lib/supabaseClient'
 
 const serviceTypes = [
     { id: 'vps', name: 'Virtual Private Server', icon: 'server', description: 'High-performance NVMe VPS', price: '100 credits/mo', cost: 100, typeName: 'VPS (Standard)' },
@@ -20,7 +21,7 @@ const regions = [
 
 export default function NewService() {
     const navigate = useNavigate()
-    const { addResource, balance, deductCredits } = useDashboard()
+    const { balance } = useDashboard()
     const [selectedType, setSelectedType] = useState(serviceTypes[0].id)
     const [selectedRegion, setSelectedRegion] = useState(regions[0].id)
     const [isDeploying, setIsDeploying] = useState(false)
@@ -37,16 +38,21 @@ export default function NewService() {
         setDeployError('')
 
         try {
-            await deductCredits(`${selectedTypeInfo.typeName} deployment`, selectedTypeInfo.cost)
-            addResource({
-                name: `${selectedTypeInfo.id}-${Math.random().toString(36).substr(2, 5)}`,
-                type: selectedTypeInfo.typeName,
-                region: regionInfo.id,
-                price: selectedTypeInfo.price
+            const response = await supabase.functions.invoke('start-reseller-order', {
+                body: { sku: selectedTypeInfo.id, region: regionInfo.id }
             })
-            navigate('/dashboard')
-        } catch {
-            setDeployError('Failed to deduct credits. Please try again.')
+
+            if (response.error) {
+                throw new Error(response.error.message || 'Unable to start order')
+            }
+
+            if (!response.data?.paymentSession?.checkout_url) {
+                throw new Error('Payment session was not returned')
+            }
+
+            window.location.href = response.data.paymentSession.checkout_url
+        } catch (error) {
+            setDeployError(error instanceof Error ? error.message : 'Failed to start order. Please try again.')
         } finally {
             setIsDeploying(false)
         }
@@ -139,7 +145,7 @@ export default function NewService() {
                             {isDeploying ? (
                                 <>
                                     <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
-                                    Deploying...
+                                    Starting order...
                                 </>
                             ) : (
                                 <>Deploy Resource</>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -379,6 +379,12 @@ verify_jwt = false
 [functions.refresh-payment-status]
 verify_jwt = false
 
+[functions.start-reseller-order]
+verify_jwt = false
+
+[functions.provider-provision]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/provider-provision/index.ts
+++ b/supabase/functions/provider-provision/index.ts
@@ -1,0 +1,36 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  try {
+    const authHeader = request.headers.get("Authorization");
+    const userClient = createUserClient(authHeader);
+    const adminClient = createAdminClient();
+
+    const { data: { user }, error: userError } = await userClient.auth.getUser();
+    if (userError || !user) return jsonResponse({ error: "You must be signed in." }, 401, request);
+
+    const { orderId } = await request.json();
+    const normalizedOrderId = String(orderId || "").trim();
+    if (!normalizedOrderId) return jsonResponse({ error: "orderId is required." }, 400, request);
+
+    const { data: order, error: orderError } = await adminClient
+      .from("orders")
+      .select("id, user_id, status")
+      .eq("id", normalizedOrderId)
+      .maybeSingle();
+
+    if (orderError || !order || order.user_id !== user.id) return jsonResponse({ error: "Order not found." }, 404, request);
+    if (order.status !== "paid") return jsonResponse({ error: "Order must be paid before provisioning." }, 409, request);
+
+    const { data, error } = await adminClient.rpc("enqueue_provision_jobs_for_order", { p_order_id: order.id });
+    if (error) return jsonResponse({ error: "Failed to enqueue provisioning jobs.", details: error.message }, 500, request);
+
+    return jsonResponse({ ok: true, jobs: data ?? 0 }, 200, request);
+  } catch (error) {
+    return jsonResponse({ error: error instanceof Error ? error.message : "Unknown error." }, 500, request);
+  }
+});

--- a/supabase/functions/start-reseller-order/index.ts
+++ b/supabase/functions/start-reseller-order/index.ts
@@ -1,0 +1,60 @@
+import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: getCorsHeaders(request) });
+  if (request.method !== "POST") return jsonResponse({ error: "Method not allowed." }, 405, request);
+
+  try {
+    const authHeader = request.headers.get("Authorization");
+    const userClient = createUserClient(authHeader);
+    const adminClient = createAdminClient();
+    const { data: { user }, error: userError } = await userClient.auth.getUser();
+    if (userError || !user) return jsonResponse({ error: "You must be signed in to deploy." }, 401, request);
+
+    const body = await request.json();
+    const sku = String(body?.sku || "").trim();
+    const region = String(body?.region || "").trim();
+    if (!sku || !region) return jsonResponse({ error: "sku and region are required." }, 400, request);
+
+    const { data: catalog, error: catalogError } = await adminClient
+      .from("reseller_skus")
+      .select("sku, price_minor, currency")
+      .eq("sku", sku)
+      .eq("is_active", true)
+      .maybeSingle();
+    if (catalogError) return jsonResponse({ error: "Failed to load SKU.", details: catalogError.message }, 500, request);
+    if (!catalog) return jsonResponse({ error: "Unknown SKU." }, 404, request);
+
+    const { data: order, error: orderError } = await adminClient
+      .from("orders")
+      .insert({ user_id: user.id, status: "pending", total_minor: catalog.price_minor, currency: catalog.currency })
+      .select("id, total_minor, currency")
+      .single();
+    if (orderError || !order) return jsonResponse({ error: "Failed to create order.", details: orderError?.message }, 500, request);
+
+    const { data: orderItem, error: itemError } = await adminClient
+      .from("order_items")
+      .insert({ order_id: order.id, sku: catalog.sku, region, unit_price_minor: catalog.price_minor, quantity: 1 })
+      .select("id")
+      .single();
+    if (itemError || !orderItem) return jsonResponse({ error: "Failed to create order item.", details: itemError?.message }, 500, request);
+
+    const paymentSession = {
+      provider: "mock",
+      checkout_url: `${new URL(request.url).origin}/dashboard/billing?order=${order.id}`,
+      amount_minor: order.total_minor,
+      currency: order.currency,
+    };
+
+    const { error: sessionError } = await adminClient
+      .from("orders")
+      .update({ payment_session: paymentSession })
+      .eq("id", order.id);
+    if (sessionError) return jsonResponse({ error: "Failed to persist payment session.", details: sessionError.message }, 500, request);
+
+    return jsonResponse({ orderId: order.id, orderItemId: orderItem.id, paymentSession }, 200, request);
+  } catch (error) {
+    return jsonResponse({ error: error instanceof Error ? error.message : "Unknown error." }, 500, request);
+  }
+});

--- a/supabase/migrations/20260501120000_reseller_order_lane.sql
+++ b/supabase/migrations/20260501120000_reseller_order_lane.sql
@@ -1,0 +1,94 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.reseller_skus (
+  sku text primary key,
+  display_name text not null,
+  price_minor integer not null check (price_minor > 0),
+  currency text not null default 'USD',
+  is_active boolean not null default true,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending','paid','failed','canceled')),
+  total_minor integer not null check (total_minor > 0),
+  currency text not null,
+  payment_session jsonb,
+  paid_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.order_items (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  sku text not null references public.reseller_skus(sku),
+  region text not null,
+  unit_price_minor integer not null check (unit_price_minor > 0),
+  quantity integer not null default 1 check (quantity > 0),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.service_resources (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  order_item_id uuid references public.order_items(id) on delete restrict,
+  sku text not null,
+  region text not null,
+  status text not null default 'queued' check (status in ('queued','provisioning','active','failed')),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.provision_jobs (
+  id uuid primary key default gen_random_uuid(),
+  service_resource_id uuid not null references public.service_resources(id) on delete cascade,
+  status text not null default 'queued' check (status in ('queued','running','done','failed')),
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create or replace function public.enqueue_provision_jobs_for_order(p_order_id uuid)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  inserted_jobs integer := 0;
+begin
+  if not exists (select 1 from public.orders o where o.id = p_order_id and o.status = 'paid') then
+    raise exception 'order_not_paid';
+  end if;
+
+  with created_resources as (
+    insert into public.service_resources (user_id, order_item_id, sku, region, status)
+    select o.user_id, oi.id, oi.sku, oi.region, 'queued'
+    from public.orders o
+    join public.order_items oi on oi.order_id = o.id
+    where o.id = p_order_id
+      and not exists (
+        select 1 from public.service_resources sr where sr.order_item_id = oi.id
+      )
+    returning id, order_item_id
+  ), created_jobs as (
+    insert into public.provision_jobs (service_resource_id, status, payload)
+    select cr.id, 'queued', jsonb_build_object('order_item_id', cr.order_item_id)
+    from created_resources cr
+    returning id
+  )
+  select count(*)::integer into inserted_jobs from created_jobs;
+
+  return inserted_jobs;
+end;
+$$;
+
+alter table public.service_resources
+  alter column order_item_id set not null;
+
+grant execute on function public.enqueue_provision_jobs_for_order(uuid) to service_role;
+grant select, insert, update on public.orders to service_role;
+grant select, insert, update on public.order_items to service_role;
+grant select, insert, update on public.service_resources to service_role;
+grant select, insert, update on public.provision_jobs to service_role;
+grant select on public.reseller_skus to service_role;


### PR DESCRIPTION
### Motivation
- Move order creation and payment session handling to server-side to avoid creating resources client-side and to centralize billing logic.
- Ensure provisioning only happens after payment is confirmed by enforcing a paid-state gate in the provisioning path.
- Provide a simple reseller SKU/order model and server-side queueing for provisioning jobs.
- Restore the previous strict schema constraint by making `service_resources.order_item_id` NOT NULL once the lane is complete.

### Description
- Added `start-reseller-order` Edge Function that authenticates the user, validates SKU and region, inserts `orders` and `order_items`, persists a mock payment session, and returns the session payload (`supabase/functions/start-reseller-order/index.ts`).
- Added `provider-provision` Edge Function which validates ownership and that `orders.status = 'paid'` before calling the database RPC `enqueue_provision_jobs_for_order` to create `service_resources` and `provision_jobs` (server-side) (`supabase/functions/provider-provision/index.ts`).
- Introduced a database migration that creates `reseller_skus`, `orders`, `order_items`, `service_resources`, and `provision_jobs`, implements `enqueue_provision_jobs_for_order(p_order_id)` (which checks the order paid state before inserting), and sets `service_resources.order_item_id` back to `NOT NULL` (`supabase/migrations/20260501120000_reseller_order_lane.sql`).
- Updated the client deploy flow in `src/pages/dashboard/NewService.jsx` to invoke the `start-reseller-order` function and redirect the browser to the returned checkout URL instead of creating resources or deducting credits client-side.
- Registered both new functions in `supabase/config.toml` so they are available to the deployment runtime.

### Testing
- Ran the repository linter via `npm run -s lint`, which reported pre-existing Biome/formatting diagnostics and did not fully pass (errors are unrelated to the new edge functions and migration). 
- No unit/integration test suite was executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40d943054832b982135460cb7c31c)