### PR TITLE
Add resource lifecycle actions, provider sync and timeline UI

### DIFF
--- a/src/context/DashboardContext.jsx
+++ b/src/context/DashboardContext.jsx
@@ -36,6 +36,32 @@ export function DashboardProvider({ children }) {
 
 	// Calculate balance from transactions
 	const balance = transactions.reduce((sum, tx) => sum + tx.amount, 0);
+	const [resourceActionState, setResourceActionState] = useState({});
+
+	const mapResource = useCallback((res) => ({
+		...res,
+		status: res.status || "Unknown",
+		events: (res.provision_events || []).slice().sort((a, b) =>
+			new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+		),
+	}), []);
+
+	const loadResources = useCallback(async () => {
+		if (!user) return;
+
+		const { data, error } = await supabase
+			.from("resources")
+			.select("id, name, type, region, ip, status, created_at, provision_events(*)")
+			.eq("user_id", user.id)
+			.order("created_at", { ascending: false });
+
+		if (error) {
+			console.warn("Unable to load resources from Supabase.", error);
+			return;
+		}
+
+		setResources((data || []).map(mapResource));
+	}, [mapResource, user]);
 
 	const loadTransactions = useCallback(async () => {
 		if (!user) {
@@ -79,6 +105,20 @@ export function DashboardProvider({ children }) {
 		loadTransactions();
 	}, [loadTransactions]);
 
+	useEffect(() => {
+		loadResources();
+	}, [loadResources]);
+
+	useEffect(() => {
+		if (!user) return undefined;
+
+		const interval = setInterval(() => {
+			loadResources();
+		}, 15000);
+
+		return () => clearInterval(interval);
+	}, [loadResources, user]);
+
 	const changePlan = (plan) => {
 		setCurrentPlan(plan);
 	};
@@ -97,6 +137,41 @@ export function DashboardProvider({ children }) {
 	const removeResource = (id) => {
 		setResources((prev) => prev.filter((r) => r.id !== id));
 	};
+
+	const setActionLoading = (id, action, loading, error = "") => {
+		setResourceActionState((prev) => ({
+			...prev,
+			[id]: {
+				action: loading ? action : "",
+				error,
+			},
+		}));
+	};
+
+	const runLifecycleAction = useCallback(
+		async (id, action) => {
+			setActionLoading(id, action, true);
+			try {
+				if (action === "delete") {
+					const { error } = await supabase.from("resources").delete().eq("id", id).eq("user_id", user.id);
+					if (error) throw error;
+				} else {
+					const { error } = await supabase
+						.from("resources")
+						.update({ status: action === "suspend" ? "Suspended" : "Running" })
+						.eq("id", id)
+						.eq("user_id", user.id);
+					if (error) throw error;
+				}
+
+				await loadResources();
+				setActionLoading(id, action, false);
+			} catch (error) {
+				setActionLoading(id, action, false, error.message || "Action failed");
+			}
+		},
+		[loadResources, user],
+	);
 
 	const deductCredits = useCallback(
 		async (description, amount) => {
@@ -118,12 +193,18 @@ export function DashboardProvider({ children }) {
 		<DashboardContext.Provider
 			value={{
 				resources,
+				resourceActionState,
 				balance,
 				transactions,
 				currentPlan,
 				addResource,
 				removeResource,
+				suspendResource: (id) => runLifecycleAction(id, "suspend"),
+				resumeResource: (id) => runLifecycleAction(id, "resume"),
+				deleteResource: (id) => runLifecycleAction(id, "delete"),
+				syncResource: loadResources,
 				deductCredits,
+				refreshResources: loadResources,
 				refreshTransactions: loadTransactions,
 				changePlan,
 			}}

--- a/src/pages/dashboard/ResourceList.jsx
+++ b/src/pages/dashboard/ResourceList.jsx
@@ -1,9 +1,8 @@
-import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { useDashboard } from '../../context/DashboardContext'
 
 export default function ResourceList({ typeFilter, title }) {
-    const { resources } = useDashboard()
+    const { resources, resourceActionState, suspendResource, resumeResource, deleteResource, syncResource } = useDashboard()
 
     const filteredResources = typeFilter
         ? resources.filter(r => r.type.toLowerCase().includes(typeFilter.toLowerCase()))
@@ -45,11 +44,17 @@ export default function ResourceList({ typeFilter, title }) {
                                     <th className="p-4 font-medium">Region</th>
                                     <th className="p-4 font-medium">IP Address</th>
                                     <th className="p-4 font-medium">Status</th>
+                                    <th className="p-4 font-medium">Timeline</th>
                                     <th className="p-4 font-medium text-right pr-6">Actions</th>
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-white/5">
                                 {filteredResources.map((res) => (
+                                    (() => {
+                                        const actionMeta = resourceActionState?.[res.id] || {}
+                                        const isBusy = Boolean(actionMeta.action)
+                                        const events = res.events || []
+                                        return (
                                     <tr key={res.id} className="hover:bg-white/5 transition-colors">
                                         <td className="p-4 pl-6 font-medium text-white">{res.name}</td>
                                         <td className="p-4 text-slate-400">{res.region}</td>
@@ -60,10 +65,35 @@ export default function ResourceList({ typeFilter, title }) {
                                                 <span className="text-green-400">{res.status}</span>
                                             </div>
                                         </td>
+                                        <td className="p-4 text-slate-400 text-xs">
+                                            {events.length === 0 ? (
+                                                <span>No events yet</span>
+                                            ) : (
+                                                <div className="space-y-1">
+                                                    {events.slice(0, 3).map((event) => (
+                                                        <div key={event.id} className="flex items-center justify-between gap-2">
+                                                            <span className="text-slate-300">{event.event_type || event.status || 'event'}</span>
+                                                            <span className="text-slate-500">{new Date(event.created_at).toLocaleString()}</span>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </td>
                                         <td className="p-4 text-right pr-6">
-                                            <button className="text-cyan-400 hover:text-cyan-300">Manage</button>
+                                            <div className="flex items-center justify-end gap-3">
+                                                <button onClick={() => syncResource()} disabled={isBusy} className="text-slate-300 hover:text-white disabled:opacity-50">Sync</button>
+                                                {res.status === 'Suspended' ? (
+                                                    <button onClick={() => resumeResource(res.id)} disabled={isBusy} className="text-emerald-400 hover:text-emerald-300 disabled:opacity-50">{actionMeta.action === 'resume' ? 'Resuming...' : 'Resume'}</button>
+                                                ) : (
+                                                    <button onClick={() => suspendResource(res.id)} disabled={isBusy} className="text-amber-400 hover:text-amber-300 disabled:opacity-50">{actionMeta.action === 'suspend' ? 'Suspending...' : 'Suspend'}</button>
+                                                )}
+                                                <button onClick={() => deleteResource(res.id)} disabled={isBusy} className="text-rose-400 hover:text-rose-300 disabled:opacity-50">{actionMeta.action === 'delete' ? 'Deleting...' : 'Delete'}</button>
+                                            </div>
+                                            {actionMeta.error && <div className="text-rose-400 text-xs mt-2">{actionMeta.error}</div>}
                                         </td>
                                     </tr>
+                                        )
+                                    })()
                                 ))}
                             </tbody>
                         </table>


### PR DESCRIPTION
### Motivation
- Surface real provider/backend state and reduce local-only optimistic divergence by loading resources from the backend (including `provision_events`) and polling for updates.
- Provide users explicit lifecycle controls (`Suspend`, `Resume`, `Delete`) and an on-demand `Sync` to reconcile UI state with the provider.
- Make resource operations observable at row level by showing recent provisioning events and surfacing per-row loading and error states.

### Description
- Load resources from Supabase with nested `provision_events` in `DashboardContext`, normalize `status` and produce a sorted `events` timeline for each resource via `mapResource` and `loadResources`.
- Add periodic backend polling (every 15s) and expose `syncResource` / `refreshResources` to keep resource state aligned with the provider.
- Introduce `resourceActionState` and `runLifecycleAction` in `DashboardContext` to perform lifecycle updates (`suspend` / `resume` / `delete`) and track per-resource loading/error metadata; expose `suspendResource`, `resumeResource`, `deleteResource` to the UI.
- Update `ResourceList.jsx` to render a `Timeline` column (showing up to 3 recent `provision_events`), add `Sync`, `Suspend`/`Resume`, and `Delete` buttons, and disable/show loading labels and row-level errors while actions are in-flight.

### Testing
- Ran a production build with `npm run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40da103e0832bb30221958e34d117)