### PR TITLE
Harden edge functions: validation, allowlists, per-user rate limits, audit metadata, and env checks

### DIFF
--- a/supabase/functions/SECURITY_PLAYBOOK.md
+++ b/supabase/functions/SECURITY_PLAYBOOK.md
@@ -1,0 +1,32 @@
+# Edge Function Security Playbook
+
+## Startup environment validation
+All edge functions should validate required environment variables at startup using `requireEnvVars` from `_shared/security.ts`.
+
+## Request schema validation
+Use explicit parser helpers in `_shared/security.ts` (`parseCreatePaymentRequest`, `parseContactRequest`) and fail fast with a 4xx response on invalid payloads.
+
+## Catalog allowlists
+For reseller/provisioning style requests, enforce server-side allowlists for:
+- `plan`
+- `region`
+- `serviceType`
+
+Current allowlist enforcement is implemented in `create-payment-session`.
+
+## Per-user quota / rate limiting
+Use `checkRateLimit(userId, endpoint, maxRequests, windowMs)` for mutable/lifecycle endpoints.
+- `create-payment-session`: 10 requests/minute/user.
+- `refresh-payment-status`: 60 requests/minute/user.
+
+## Audit metadata on mutable operations
+Use `getAuditMetadata(request, actorId)` and persist audit context alongside writes.
+
+## Secret rotation runbook
+1. Generate new provider secrets in upstream vendors (Supabase, SafePay, mail provider).
+2. Add new secrets to the deployment environment without removing old values.
+3. Deploy functions that can read the new values.
+4. Validate startup checks pass and smoke test auth/payment/contact endpoints.
+5. Revoke old secrets in provider dashboards.
+6. Redeploy and verify logs contain no `Missing required environment variables` or auth errors.
+7. Record rotation timestamp and owner in incident/security log.

--- a/supabase/functions/_shared/security.ts
+++ b/supabase/functions/_shared/security.ts
@@ -1,0 +1,149 @@
+const rateWindowStore = new Map<string, { count: number; resetAt: number }>();
+
+export type AuditMetadata = {
+	actorId: string | null;
+	requestId: string;
+	correlationId: string;
+	timestamp: string;
+};
+
+export function requireEnvVars(vars: string[]) {
+	const missing = vars.filter((name) => !Deno.env.get(name));
+	if (missing.length > 0) {
+		throw new Error(
+			`Missing required environment variables: ${missing.join(", ")}`,
+		);
+	}
+}
+
+export function getAuditMetadata(
+	request: Request,
+	actorId: string | null,
+): AuditMetadata {
+	const requestId =
+		request.headers.get("x-request-id") ||
+		request.headers.get("cf-ray") ||
+		crypto.randomUUID();
+	const correlationId = request.headers.get("x-correlation-id") || requestId;
+
+	return {
+		actorId,
+		requestId,
+		correlationId,
+		timestamp: new Date().toISOString(),
+	};
+}
+
+export function withAudit<T extends Record<string, unknown>>(
+	payload: T,
+	audit: AuditMetadata,
+): T & { audit_metadata: AuditMetadata } {
+	return {
+		...payload,
+		audit_metadata: audit,
+	};
+}
+
+export function enforceAllowlist(
+	value: string,
+	allowlist: readonly string[],
+	field: string,
+) {
+	if (!allowlist.includes(value)) {
+		throw new Error(
+			`Invalid ${field}. Allowed values: ${allowlist.join(", ")}`,
+		);
+	}
+}
+
+export function assertObject(
+	value: unknown,
+	name: string,
+): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`${name} must be an object.`);
+	}
+	return value as Record<string, unknown>;
+}
+
+export function checkRateLimit(
+	userId: string,
+	endpoint: string,
+	maxRequests: number,
+	windowMs: number,
+) {
+	const now = Date.now();
+	const key = `${endpoint}:${userId}`;
+	const current = rateWindowStore.get(key);
+
+	if (!current || now >= current.resetAt) {
+		rateWindowStore.set(key, { count: 1, resetAt: now + windowMs });
+		return {
+			allowed: true,
+			remaining: maxRequests - 1,
+			resetAt: now + windowMs,
+		};
+	}
+
+	if (current.count >= maxRequests) {
+		return { allowed: false, remaining: 0, resetAt: current.resetAt };
+	}
+
+	current.count += 1;
+	rateWindowStore.set(key, current);
+	return {
+		allowed: true,
+		remaining: maxRequests - current.count,
+		resetAt: current.resetAt,
+	};
+}
+
+export function parseContactRequest(rawBody: unknown) {
+	const body = assertObject(rawBody, "Request body");
+	const firstName = String(body.firstName || "").trim();
+	const lastName = String(body.lastName || "").trim();
+	const email = String(body.email || "").trim();
+	const phone = String(body.phone || "").trim();
+	const company = String(body.company || "").trim();
+	const cloudSpend = String(body.cloudSpend || "").trim();
+	const message = String(body.message || "").trim();
+
+	if (!email || !message) {
+		throw new Error("Email and message are required.");
+	}
+
+	return { firstName, lastName, email, phone, company, cloudSpend, message };
+}
+
+export function parseCreatePaymentRequest(rawBody: unknown) {
+	const body = assertObject(rawBody, "Request body");
+	const currency = String(body.currency || "")
+		.trim()
+		.toUpperCase();
+	const amount = body.amount;
+	const customer = body.customer ? assertObject(body.customer, "customer") : {};
+	const serviceType = String(body.serviceType || "credits")
+		.trim()
+		.toLowerCase();
+	const region = String(body.region || "global")
+		.trim()
+		.toLowerCase();
+	const plan = String(body.plan || "topup")
+		.trim()
+		.toLowerCase();
+
+	return {
+		currency,
+		amount,
+		customer,
+		serviceType,
+		region,
+		plan,
+	};
+}
+
+export function getEnvOrThrow(name: string) {
+	const value = Deno.env.get(name);
+	if (!value) throw new Error(`Missing required environment variable: ${name}`);
+	return value;
+}

--- a/supabase/functions/contact-form/index.ts
+++ b/supabase/functions/contact-form/index.ts
@@ -1,5 +1,12 @@
 import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
 import { MAIL_FROM, MAIL_TO, sendEmail } from "../_shared/mailer.ts";
+import {
+	getAuditMetadata,
+	parseContactRequest,
+	requireEnvVars,
+} from "../_shared/security.ts";
+
+requireEnvVars(["RESEND_API_KEY", "MAIL_FROM", "MAIL_TO"]);
 
 Deno.serve(async (request) => {
 	if (request.method === "OPTIONS") {
@@ -11,22 +18,10 @@ Deno.serve(async (request) => {
 	}
 
 	try {
-		const body = await request.json();
-		const firstName = String(body?.firstName || "").trim();
-		const lastName = String(body?.lastName || "").trim();
-		const email = String(body?.email || "").trim();
-		const phone = String(body?.phone || "").trim();
-		const company = String(body?.company || "").trim();
-		const cloudSpend = String(body?.cloudSpend || "").trim();
-		const message = String(body?.message || "").trim();
-
-		if (!email || !message) {
-			return jsonResponse(
-				{ error: "Email and message are required." },
-				400,
-				request,
-			);
-		}
+		const parsed = parseContactRequest(await request.json());
+		const { firstName, lastName, email, phone, company, cloudSpend, message } =
+			parsed;
+		const audit = getAuditMetadata(request, email || null);
 
 		await sendEmail({
 			from: MAIL_FROM,
@@ -34,6 +29,7 @@ Deno.serve(async (request) => {
 			subject: `Contact Form: ${firstName} ${lastName} — ${company || email}`,
 			html: `
 				<h2>New Contact Form Submission</h2>
+				<p><strong>Actor:</strong> ${audit.actorId || "anonymous"}<br/><strong>Request ID:</strong> ${audit.requestId}<br/><strong>Correlation ID:</strong> ${audit.correlationId}</p>
 				<table cellpadding="6" style="border-collapse:collapse;font-family:sans-serif;font-size:14px;">
 					<tr><td><strong>Name</strong></td><td>${firstName} ${lastName}</td></tr>
 					<tr><td><strong>Email</strong></td><td><a href="mailto:${email}">${email}</a></td></tr>

--- a/supabase/functions/create-payment-session/index.ts
+++ b/supabase/functions/create-payment-session/index.ts
@@ -13,21 +13,42 @@ import {
 	parseCreatePaymentResponse,
 } from "../../../shared/payments/safepay-server.js";
 import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+	checkRateLimit,
+	enforceAllowlist,
+	getAuditMetadata,
+	getEnvOrThrow,
+	parseCreatePaymentRequest,
+	requireEnvVars,
+} from "../_shared/security.ts";
 import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
 
 const gatewayUrl =
 	Deno.env.get("SAFEPAY_GATEWAY_URL") ||
 	"https://www.safepayto.me/new/gateway/";
 
-function requiredEnv(name: string) {
-	const value = Deno.env.get(name);
+const PLAN_ALLOWLIST = ["topup", "starter", "pro", "business"] as const;
+const REGION_ALLOWLIST = [
+	"global",
+	"us-east",
+	"eu-central",
+	"ap-southeast",
+] as const;
+const SERVICE_TYPE_ALLOWLIST = [
+	"credits",
+	"vps",
+	"k8s",
+	"database",
+	"gpu",
+] as const;
 
-	if (!value) {
-		throw new Error(`Missing required environment variable: ${name}`);
-	}
-
-	return value;
-}
+requireEnvVars([
+	"SUPABASE_URL",
+	"SUPABASE_ANON_KEY",
+	"SUPABASE_SERVICE_ROLE_KEY",
+	"SAFEPAY_MERCHANT_ID",
+	"SAFEPAY_MERCHANT_SECRET",
+]);
 
 Deno.serve(async (request) => {
 	if (request.method === "OPTIONS") {
@@ -56,16 +77,20 @@ Deno.serve(async (request) => {
 			);
 		}
 
-		const body = await request.json();
-		const currency = String(body?.currency || "").toUpperCase();
-		const merchantId = requiredEnv("SAFEPAY_MERCHANT_ID");
-		const merchantSecret = requiredEnv("SAFEPAY_MERCHANT_SECRET");
+		const parsedBody = parseCreatePaymentRequest(await request.json());
+		const { currency, amount, customer, plan, region, serviceType } =
+			parsedBody;
+		enforceAllowlist(plan, PLAN_ALLOWLIST, "plan");
+		enforceAllowlist(region, REGION_ALLOWLIST, "region");
+		enforceAllowlist(serviceType, SERVICE_TYPE_ALLOWLIST, "service type");
+		const merchantId = getEnvOrThrow("SAFEPAY_MERCHANT_ID");
+		const merchantSecret = getEnvOrThrow("SAFEPAY_MERCHANT_SECRET");
 
 		let amountMinor: number;
 		let creditsToAdd: number;
 
 		try {
-			amountMinor = amountMajorToMinor(body?.amount, currency);
+			amountMinor = amountMajorToMinor(amount, currency);
 			creditsToAdd = creditsFromMinorAmount(amountMinor, currency);
 		} catch (error) {
 			return jsonResponse(
@@ -99,12 +124,12 @@ Deno.serve(async (request) => {
 		}
 
 		const normalizedCustomer = normalizeCustomerProfile({
-			firstName: body?.customer?.firstName || existingProfile?.first_name,
-			lastName: body?.customer?.lastName || existingProfile?.last_name,
+			firstName: customer.firstName || existingProfile?.first_name,
+			lastName: customer.lastName || existingProfile?.last_name,
 			email: user.email || existingProfile?.email,
-			phone: body?.customer?.phone || existingProfile?.phone,
-			countryCode: body?.customer?.countryCode || existingProfile?.country_code,
-			city: body?.customer?.city || existingProfile?.city,
+			phone: customer.phone || existingProfile?.phone,
+			countryCode: customer.countryCode || existingProfile?.country_code,
+			city: customer.city || existingProfile?.city,
 		});
 		const missingFields = getMissingCustomerFields(normalizedCustomer);
 
@@ -213,6 +238,17 @@ Deno.serve(async (request) => {
 			);
 		}
 
+		const rate = checkRateLimit(user.id, "create-payment-session", 10, 60_000);
+		if (!rate.allowed) {
+			return jsonResponse(
+				{ error: "Rate limit exceeded. Try again later." },
+				429,
+				request,
+			);
+		}
+
+		const audit = getAuditMetadata(request, user.id);
+
 		const { data: order, error: orderError } = await adminClient
 			.from("payment_orders")
 			.insert({
@@ -230,7 +266,11 @@ Deno.serve(async (request) => {
 				customer_phone: normalizedCustomer.phone,
 				customer_country_code: normalizedCustomer.countryCode,
 				customer_city: normalizedCustomer.city,
-				raw_create_response: providerText,
+				raw_create_response: JSON.stringify({
+					providerText,
+					audit,
+					catalog: { plan, region, serviceType },
+				}),
 			})
 			.select("id")
 			.single();

--- a/supabase/functions/refresh-payment-status/index.ts
+++ b/supabase/functions/refresh-payment-status/index.ts
@@ -3,26 +3,30 @@ import { summarizeRefreshResult } from "../../../shared/payments/reconciliation.
 import { buildRequestHash } from "../../../shared/payments/safepay-server.js";
 import { getCorsHeaders, jsonResponse } from "../_shared/cors.ts";
 import { MAIL_FROM, MAIL_TO, sendEmail } from "../_shared/mailer.ts";
+import {
+	checkRateLimit,
+	getAuditMetadata,
+	getEnvOrThrow,
+	requireEnvVars,
+} from "../_shared/security.ts";
 import { createAdminClient, createUserClient } from "../_shared/supabase.ts";
 
 const gatewayUrl =
 	Deno.env.get("SAFEPAY_GATEWAY_URL") ||
 	"https://www.safepayto.me/new/gateway/";
 
-function requiredEnv(name: string) {
-	const value = Deno.env.get(name);
-
-	if (!value) {
-		throw new Error(`Missing required environment variable: ${name}`);
-	}
-
-	return value;
-}
-
 function toProviderStatusId(value: unknown) {
 	const parsed = Number(value);
 	return Number.isInteger(parsed) ? parsed : null;
 }
+
+requireEnvVars([
+	"SUPABASE_URL",
+	"SUPABASE_ANON_KEY",
+	"SUPABASE_SERVICE_ROLE_KEY",
+	"SAFEPAY_MERCHANT_ID",
+	"SAFEPAY_MERCHANT_SECRET",
+]);
 
 Deno.serve(async (request) => {
 	if (request.method === "OPTIONS") {
@@ -52,7 +56,9 @@ Deno.serve(async (request) => {
 		}
 
 		const body = await request.json();
-		const invoice = String(body?.invoice || "").trim();
+		const invoice = String(
+			(body as Record<string, unknown>)?.invoice || "",
+		).trim();
 
 		if (!invoice) {
 			return jsonResponse({ error: "Invoice is required." }, 400, request);
@@ -70,8 +76,19 @@ Deno.serve(async (request) => {
 			return jsonResponse({ error: "Payment not found." }, 404, request);
 		}
 
-		const merchantId = requiredEnv("SAFEPAY_MERCHANT_ID");
-		const merchantSecret = requiredEnv("SAFEPAY_MERCHANT_SECRET");
+		const merchantId = getEnvOrThrow("SAFEPAY_MERCHANT_ID");
+		const merchantSecret = getEnvOrThrow("SAFEPAY_MERCHANT_SECRET");
+
+		const rate = checkRateLimit(user.id, "refresh-payment-status", 60, 60_000);
+		if (!rate.allowed) {
+			return jsonResponse(
+				{ error: "Rate limit exceeded. Try again later." },
+				429,
+				request,
+			);
+		}
+
+		const audit = getAuditMetadata(request, user.id);
 
 		const payload = new URLSearchParams({
 			_cmd: "request",
@@ -117,7 +134,7 @@ Deno.serve(async (request) => {
 				.from("payment_orders")
 				.update({
 					last_checked_at: new Date().toISOString(),
-					raw_status_response: providerJson,
+					raw_status_response: { providerJson, audit },
 					provider_status_text: String(
 						providerJson.error || providerJson.error_code || "pending",
 					),
@@ -176,7 +193,7 @@ Deno.serve(async (request) => {
 				provider_status_text: providerStatusText,
 				provider_transaction_id:
 					refreshSummary.providerTransactionId || order.provider_transaction_id,
-				raw_status_response: providerJson,
+				raw_status_response: { providerJson, audit },
 				last_checked_at: nowIso,
 				completed_at:
 					refreshSummary.status === "completed"


### PR DESCRIPTION
### Motivation

- Ensure reseller/payment/contact edge functions validate inputs and fail fast to reduce malformed requests and abuse.  
- Enforce server-side catalog allowlists (plan, region, service type) so clients cannot bypass product constraints.  
- Add per-user quotas, audit metadata, and startup env checks to improve observability, operations, and secure secret rotation.

### Description

- Added `supabase/functions/_shared/security.ts` implementing `requireEnvVars`, `getEnvOrThrow`, strict parsers (`parseCreatePaymentRequest`, `parseContactRequest`), `enforceAllowlist`, `getAuditMetadata`, `withAudit`, and an in-memory `checkRateLimit` limiter.  
- Hardened `create-payment-session` to use `parseCreatePaymentRequest`, enforce plan/region/service-type allowlists, apply per-user rate limiting (`10 req/min`), validate startup envs, and persist audit + catalog context into the payment order (`raw_create_response`).  
- Hardened `refresh-payment-status` with startup env validation, invoice normalization, per-user rate limiting (`60 req/min`), and audit metadata attached to `raw_status_response` during mutable updates.  
- Hardened `contact-form` to validate startup envs, parse and validate the payload via `parseContactRequest`, and include audit metadata in the notification email.  
- Added `supabase/functions/SECURITY_PLAYBOOK.md` documenting startup env validation, request schema validation, catalog allowlists, rate-limiting policy, audit metadata expectations, and a secret-rotation runbook.

### Testing

- Ran formatter and lint/check on modified files using `npx biome format --write supabase/functions/_shared/security.ts supabase/functions/contact-form/index.ts supabase/functions/create-payment-session/index.ts supabase/functions/refresh-payment-status/index.ts` and `npx biome check --write supabase/functions/create-payment-session/index.ts supabase/functions/refresh-payment-status/index.ts`, which completed successfully.  
- Ran `npx biome check supabase/functions/contact-form/index.ts supabase/functions/create-payment-session/index.ts supabase/functions/refresh-payment-status/index.ts supabase/functions/_shared/security.ts`, which completed successfully with no remaining errors on the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40da2f77c832b93c5f4fb6041599f)