### PR TITLE
Admin observability: queue/failure alerts, rollout flags, daily reconciliation job, and runbooks

### DIFF
--- a/scripts/supabase-reconciliation-job.sql
+++ b/scripts/supabase-reconciliation-job.sql
@@ -1,0 +1,53 @@
+-- Daily paid-vs-provisioned reconciliation
+create table if not exists public.provisioning_reconciliation (
+  id bigserial primary key,
+  day date not null default current_date,
+  paid_count integer not null,
+  provisioned_count integer not null,
+  mismatch_count integer not null,
+  status text not null default 'ok',
+  created_at timestamptz not null default now()
+);
+
+create or replace function public.run_daily_provisioning_reconciliation()
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  paid_total integer := 0;
+  provisioned_total integer := 0;
+  mismatch_total integer := 0;
+begin
+  select count(*) into paid_total
+  from public.credit_transactions
+  where type = 'credit'
+    and status = 'Completed'
+    and created_at::date = current_date;
+
+  select count(*) into provisioned_total
+  from public.credit_transactions
+  where type = 'debit'
+    and description ilike '%provision%'
+    and created_at::date = current_date;
+
+  mismatch_total := abs(paid_total - provisioned_total);
+
+  insert into public.provisioning_reconciliation(day, paid_count, provisioned_count, mismatch_count, status)
+  values (
+    current_date,
+    paid_total,
+    provisioned_total,
+    mismatch_total,
+    case when mismatch_total > 0 then 'mismatch' else 'ok' end
+  );
+end;
+$$;
+
+-- Requires pg_cron extension in Supabase
+select cron.schedule(
+  'daily-provisioning-reconciliation',
+  '15 0 * * *',
+  $$select public.run_daily_provisioning_reconciliation();$$
+)
+where exists (select 1 from pg_extension where extname = 'pg_cron');

--- a/src/pages/dashboard/AdminObservability.jsx
+++ b/src/pages/dashboard/AdminObservability.jsx
@@ -118,6 +118,9 @@ export default function AdminObservability() {
 	const [roles, setRoles] = useState([]);
 	const [transactions, setTransactions] = useState([]);
 
+	const [serviceFlags, setServiceFlags] = useState([]);
+	const [reconciliationRows, setReconciliationRows] = useState([]);
+
 	// Filter / pagination state
 	const [dateRange, setDateRange] = useState("all");
 	const [txSearch, setTxSearch] = useState("");
@@ -135,7 +138,7 @@ export default function AdminObservability() {
 		}
 		setLoading(true);
 		setError("");
-		const [profilesRes, rolesRes, txRes] = await Promise.all([
+		const [profilesRes, rolesRes, txRes, flagsRes, reconRes] = await Promise.all([
 			supabase
 				.from("profiles")
 				.select("id, email, created_at")
@@ -149,6 +152,16 @@ export default function AdminObservability() {
 				.select("id, user_id, description, amount, type, status, created_at")
 				.order("created_at", { ascending: false })
 				.limit(300),
+			supabase
+				.from("service_rollout_flags")
+				.select("id, service_type, region, enabled, rollout_percent, updated_at")
+				.order("service_type", { ascending: true })
+				.limit(200),
+			supabase
+				.from("provisioning_reconciliation")
+				.select("id, day, paid_count, provisioned_count, mismatch_count, status, created_at")
+				.order("day", { ascending: false })
+				.limit(30),
 		]);
 		if (profilesRes.error || rolesRes.error || txRes.error) {
 			setError(
@@ -163,6 +176,8 @@ export default function AdminObservability() {
 		setProfiles(profilesRes.data || []);
 		setRoles(rolesRes.data || []);
 		setTransactions(txRes.data || []);
+		setServiceFlags(flagsRes.error ? [] : flagsRes.data || []);
+		setReconciliationRows(reconRes.error ? [] : reconRes.data || []);
 		setLoading(false);
 	}, [isAdmin, adminLoading]);
 
@@ -315,6 +330,35 @@ export default function AdminObservability() {
 	);
 
 	const recentUsers = profiles.slice(0, 8);
+
+	const queueBacklog = rangeTransactions.filter((tx) => tx.status === "Queued").length;
+	const deadLetterCount = rangeTransactions.filter((tx) => tx.status === "DeadLetter").length;
+	const providerFailures = rangeTransactions.filter((tx) =>
+		(tx.status || "").toLowerCase().includes("provider_fail"),
+	).length;
+	const paymentProvisionMismatch = reconciliationRows
+		.reduce((sum, row) => sum + (row.mismatch_count || 0), 0);
+
+	const alertCards = [
+		{
+			id: "dead-letter",
+			label: "Dead-letter growth",
+			value: deadLetterCount,
+			state: deadLetterCount > 10 ? "Critical" : deadLetterCount > 0 ? "Watch" : "Healthy",
+		},
+		{
+			id: "provider-failures",
+			label: "Provider API failure spikes",
+			value: providerFailures,
+			state: providerFailures > 8 ? "Critical" : providerFailures > 0 ? "Watch" : "Healthy",
+		},
+		{
+			id: "mismatch",
+			label: "Payment/provision mismatch",
+			value: paymentProvisionMismatch,
+			state: paymentProvisionMismatch > 0 ? "Critical" : "Healthy",
+		},
+	];
 
 	// ─── Guards ──────────────────────────────────────────────────────────────────
 
@@ -787,6 +831,60 @@ export default function AdminObservability() {
 							);
 						})}
 					</div>
+				</div>
+			</div>
+
+
+			{/* Queue + Failure Metrics */}
+			<div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h2 className="font-bold text-lg">Queue Health</h2>
+					<p className="text-xs text-slate-500 mb-4">Backlog and dead-letter trends</p>
+					<p className="text-3xl font-bold text-cyan-300">{queueBacklog}</p>
+					<p className="text-xs text-slate-500">queued events</p>
+					<p className="mt-3 text-lg font-semibold text-red-300">{deadLetterCount}</p>
+					<p className="text-xs text-slate-500">dead-lettered events</p>
+				</div>
+				<div className="xl:col-span-2 rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h2 className="font-bold text-lg mb-3">Operational Alerts</h2>
+					<div className="grid sm:grid-cols-3 gap-3">
+						{alertCards.map((alert) => (
+							<div key={alert.id} className="rounded-xl border border-white/10 p-3 bg-black/20">
+								<p className="text-xs text-slate-500">{alert.label}</p>
+								<p className="text-2xl font-bold text-white mt-1">{alert.value}</p>
+								<p className={`text-xs mt-1 ${alert.state === "Critical" ? "text-red-300" : alert.state === "Watch" ? "text-amber-300" : "text-emerald-300"}`}>{alert.state}</p>
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+
+			{/* Feature Flags + Reconciliation + Runbooks */}
+			<div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+				<div className="xl:col-span-2 rounded-2xl border border-white/10 bg-[#0d1527] overflow-hidden">
+					<div className="p-4 border-b border-white/5">
+						<h2 className="font-bold">Service Rollout Flags</h2>
+						<p className="text-xs text-slate-500">Per service type and region phased rollout</p>
+					</div>
+					<div className="divide-y divide-white/5">
+						{serviceFlags.length === 0 ? <p className="p-4 text-sm text-slate-500">No rollout flags found.</p> : serviceFlags.slice(0, 12).map((flag) => (
+							<div key={flag.id} className="p-3 grid grid-cols-4 gap-2 text-sm">
+								<p className="text-white">{flag.service_type}</p>
+								<p className="text-slate-300">{flag.region}</p>
+								<p className="text-cyan-300">{flag.rollout_percent || 0}%</p>
+								<p className={flag.enabled ? "text-emerald-300" : "text-slate-500"}>{flag.enabled ? "Enabled" : "Disabled"}</p>
+							</div>
+						))}
+					</div>
+				</div>
+				<div className="rounded-2xl border border-white/10 bg-[#0d1527] p-5">
+					<h2 className="font-bold text-lg">Incident Runbooks</h2>
+					<ul className="mt-3 space-y-2 text-sm text-slate-300 list-disc list-inside">
+						<li>Retry pipeline: replay transient failures with exponential backoff.</li>
+						<li>Rollback: disable impacted region flags and halt new provisioning.</li>
+						<li>Orphan cleanup: detect paid-but-unprovisioned resources and reconcile.</li>
+						<li>Provider outage mode: shift to degraded mode and queue async retries.</li>
+					</ul>
 				</div>
 			</div>
 


### PR DESCRIPTION
### Motivation
- Provide richer backoffice observability for queue and provider failures and detect paid vs provisioned inconsistencies.  
- Surface phased rollout controls so services can be rolled out by `service_type` + `region` during incidents.  
- Automate daily reconciliation to detect payment/provision mismatches and enable operational runbooks for common incidents.  

### Description
- Extended `src/pages/dashboard/AdminObservability.jsx` to fetch `service_rollout_flags` and `provisioning_reconciliation`, added `serviceFlags` and `reconciliationRows` state, and added computed signals (`queueBacklog`, `deadLetterCount`, `providerFailures`, `paymentProvisionMismatch`) and `alertCards`.  
- Added UI panels to the Admin Observability page showing Queue Health, Operational Alerts, Service Rollout Flags (per service type + region), and a concise Incident Runbooks section (retry, rollback, orphan cleanup, provider outage mode).  
- Added `scripts/supabase-reconciliation-job.sql` which creates the `provisioning_reconciliation` table, a `run_daily_provisioning_reconciliation()` PL/pgSQL function, and schedules it via `pg_cron` when available.  
- All new dashboard code is defensive and shows empty states when the optional tables are not present.  

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build succeeded; there was a non-fatal chunk size warning).  
- No additional automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40da4587c832b82e43bd416183298)