### PR TITLE
Enforce paid-order linkage for provider provisioning

### DIFF
--- a/docs/reseller-provisioning-contract.md
+++ b/docs/reseller-provisioning-contract.md
@@ -1,0 +1,37 @@
+# Reseller Provisioning Contract
+
+## Overview
+
+`provider-provision` now enforces a strict paid-order linkage before any provisioning job is accepted into the queue.
+
+This contract applies to both queue-based and direct provisioning flows.
+
+## Validation Rules
+
+1. `order_id` is required for all provisioning requests.
+2. `order_id` must resolve to a reseller-owned order.
+3. The linked order must have `status = paid`.
+4. If any check fails, provisioning is rejected and **no** job is queued.
+
+## Direct Provisioning Guard
+
+Use `public.provider_provision_direct(...)` to perform guarded direct provisioning.
+
+The function validates the order linkage and order status before inserting into `public.provider_provision_jobs`.
+
+## Error Codes
+
+Provisioning failures are emitted as SQL exceptions with details including one of:
+
+- `PROVISION_ORDER_LINK_REQUIRED`
+  - `order_id` was omitted.
+- `PROVISION_ORDER_LINK_MISSING`
+  - `order_id` does not exist for the reseller, or linkage is invalid.
+- `PROVISION_ORDER_NOT_PAID`
+  - the order exists but status is not `paid`.
+
+## Referential Behavior
+
+`public.provider_provision_jobs.order_id` is `NOT NULL` and references `public.reseller_orders(id)` with `ON DELETE RESTRICT`.
+
+This restores strict referential behavior so order/provision integrity is enforced at the database layer.

--- a/supabase/migrations/20260501090000_reseller_provisioning_paid_order_guard.sql
+++ b/supabase/migrations/20260501090000_reseller_provisioning_paid_order_guard.sql
@@ -1,0 +1,131 @@
+begin;
+
+-- Status contract: provisioning may only proceed for paid orders.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'order_payment_status'
+      and n.nspname = 'public'
+  ) then
+    create type public.order_payment_status as enum ('pending', 'paid', 'failed', 'cancelled');
+  end if;
+end $$;
+
+create table if not exists public.reseller_orders (
+  id uuid primary key default gen_random_uuid(),
+  reseller_id uuid not null references auth.users(id) on delete cascade,
+  status public.order_payment_status not null default 'pending',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.provider_provision_jobs (
+  id bigserial primary key,
+  reseller_id uuid not null references auth.users(id) on delete cascade,
+  provider_slug text not null,
+  payload jsonb not null,
+  order_id uuid not null references public.reseller_orders(id) on delete restrict,
+  status text not null default 'queued' check (status in ('queued', 'processing', 'completed', 'failed')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists provider_provision_jobs_order_id_idx
+  on public.provider_provision_jobs (order_id);
+
+create or replace function public.reseller_order_must_be_paid()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.order_id is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Provisioning order linkage is required',
+      detail = 'error_code=PROVISION_ORDER_LINK_REQUIRED';
+  end if;
+
+  if not exists (
+    select 1
+    from public.reseller_orders ro
+    where ro.id = new.order_id
+      and ro.status = 'paid'
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Provisioning order must be paid before queueing',
+      detail = 'error_code=PROVISION_ORDER_NOT_PAID';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_provider_provision_jobs_paid_guard on public.provider_provision_jobs;
+create trigger trg_provider_provision_jobs_paid_guard
+before insert or update of order_id on public.provider_provision_jobs
+for each row execute function public.reseller_order_must_be_paid();
+
+create or replace function public.provider_provision_direct(
+  p_reseller_id uuid,
+  p_provider_slug text,
+  p_payload jsonb,
+  p_order_id uuid
+)
+returns bigint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status public.order_payment_status;
+  v_job_id bigint;
+begin
+  if p_order_id is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Provisioning order linkage is required',
+      detail = 'error_code=PROVISION_ORDER_LINK_REQUIRED';
+  end if;
+
+  select ro.status
+  into v_status
+  from public.reseller_orders ro
+  where ro.id = p_order_id
+    and ro.reseller_id = p_reseller_id;
+
+  if v_status is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Provisioning order linkage is missing or invalid',
+      detail = 'error_code=PROVISION_ORDER_LINK_MISSING';
+  end if;
+
+  if v_status <> 'paid' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Direct provisioning is only allowed for paid orders',
+      detail = 'error_code=PROVISION_ORDER_NOT_PAID';
+  end if;
+
+  insert into public.provider_provision_jobs (
+    reseller_id,
+    provider_slug,
+    payload,
+    order_id
+  )
+  values (
+    p_reseller_id,
+    p_provider_slug,
+    coalesce(p_payload, '{}'::jsonb),
+    p_order_id
+  )
+  returning id into v_job_id;
+
+  return v_job_id;
+end;
+$$;
+
+commit;


### PR DESCRIPTION
### Motivation

- Prevent provisioning jobs from being queued or executed unless tied to a paid reseller order to preserve billing integrity.
- Provide explicit, machine-parsable error signals when order linkage is missing or unpaid to simplify caller handling.
- Restore strict referential behavior between provision jobs and orders so database-level integrity prevents orphaned jobs.

### Description

- Add a new migration `supabase/migrations/20260501090000_reseller_provisioning_paid_order_guard.sql` that defines `public.order_payment_status`, creates `public.reseller_orders` and `public.provider_provision_jobs`, and enforces `order_id` as `NOT NULL` with `ON DELETE RESTRICT`.
- Add a trigger `trg_provider_provision_jobs_paid_guard` (function `public.reseller_order_must_be_paid()`) that rejects inserts/updates when `order_id` is missing or the linked order is not `paid` and returns detailed error codes.
- Introduce `public.provider_provision_direct(...)` to handle guarded direct provisioning and to return explicit failure details `PROVISION_ORDER_LINK_REQUIRED`, `PROVISION_ORDER_LINK_MISSING`, and `PROVISION_ORDER_NOT_PAID` when applicable.
- Backfill documentation in `docs/reseller-provisioning-contract.md` describing validation rules, error codes, direct-provision guard, and the expected referential behavior.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40db39e98832b91e412d83279aa2d)