### PR TITLE
Harden service resource provisioning around order-backed payments

### DIFF
--- a/docs/migrations/20260501-order-item-resource-hardening.md
+++ b/docs/migrations/20260501-order-item-resource-hardening.md
@@ -1,0 +1,30 @@
+# Migration: enforce `service_resources.order_item_id` NOT NULL
+
+Date: 2026-05-01
+Migration file: `supabase/migrations/20260501120000_enforce_order_item_resources.sql`
+
+## What changes
+
+1. Deletes legacy `service_resources` rows where `order_item_id IS NULL`.
+2. Sets `service_resources.order_item_id` to `NOT NULL`.
+3. Recreates FK from `service_resources.order_item_id -> order_items.id` with `ON DELETE RESTRICT`.
+4. Adds a unique index on `service_resources(order_item_id)` to avoid duplicate resources per order item.
+
+## Rollback strategy
+
+If deployment must be rolled back:
+
+1. **Drop strict constraints/index**:
+   - `drop index if exists public.service_resources_order_item_id_unique;`
+   - `alter table public.service_resources drop constraint if exists service_resources_order_item_id_fkey;`
+2. **Allow nullable order links again**:
+   - `alter table public.service_resources alter column order_item_id drop not null;`
+3. **Restore previous FK behavior** (if it was `ON DELETE SET NULL`):
+   - `alter table public.service_resources add constraint service_resources_order_item_id_fkey foreign key (order_item_id) references public.order_items(id) on delete set null;`
+4. **Data recovery**:
+   - Restore deleted direct-provision rows from backup/PITR if needed.
+
+## Operational notes
+
+- Run `scripts/cleanup-direct-provision-service-resources.sql` before migration in environments with unknown historical data volume.
+- Take a DB snapshot (or ensure PITR checkpoint) before running cleanup + migration.

--- a/scripts/cleanup-direct-provision-service-resources.sql
+++ b/scripts/cleanup-direct-provision-service-resources.sql
@@ -1,0 +1,9 @@
+-- Preview rows that will be deleted.
+select id, user_id, order_item_id, status, created_at
+from public.service_resources
+where order_item_id is null
+order by created_at asc;
+
+-- Delete direct-provision era rows (no order item link).
+delete from public.service_resources
+where order_item_id is null;

--- a/src/pages/dashboard/NewService.jsx
+++ b/src/pages/dashboard/NewService.jsx
@@ -20,36 +20,23 @@ const regions = [
 
 export default function NewService() {
     const navigate = useNavigate()
-    const { addResource, balance, deductCredits } = useDashboard()
+    const { balance } = useDashboard()
     const [selectedType, setSelectedType] = useState(serviceTypes[0].id)
     const [selectedRegion, setSelectedRegion] = useState(regions[0].id)
-    const [isDeploying, setIsDeploying] = useState(false)
-    const [deployError, setDeployError] = useState('')
 
     const selectedTypeInfo = serviceTypes.find(t => t.id === selectedType)
     const canDeploy = balance >= selectedTypeInfo.cost
 
-    const handleDeploy = async () => {
+    const handleDeploy = () => {
         if (!canDeploy) return
 
-        const regionInfo = regions.find(r => r.id === selectedRegion)
-        setIsDeploying(true)
-        setDeployError('')
+        const checkoutParams = new URLSearchParams({
+            intent: 'resource-order',
+            serviceType: selectedTypeInfo.id,
+            region: selectedRegion,
+        })
 
-        try {
-            await deductCredits(`${selectedTypeInfo.typeName} deployment`, selectedTypeInfo.cost)
-            addResource({
-                name: `${selectedTypeInfo.id}-${Math.random().toString(36).substr(2, 5)}`,
-                type: selectedTypeInfo.typeName,
-                region: regionInfo.id,
-                price: selectedTypeInfo.price
-            })
-            navigate('/dashboard')
-        } catch {
-            setDeployError('Failed to deduct credits. Please try again.')
-        } finally {
-            setIsDeploying(false)
-        }
+        navigate(`/dashboard/billing?${checkoutParams.toString()}`)
     }
 
     return (
@@ -127,23 +114,16 @@ export default function NewService() {
                             </p>
                         )}
 
-                        {deployError && (
-                            <p className="text-red-400 text-sm mb-4">{deployError}</p>
-                        )}
+                        <p className="text-slate-400 text-xs mb-4">
+                            Resources are now created only after successful payment confirmation.
+                        </p>
 
                         <button
                             onClick={handleDeploy}
-                            disabled={isDeploying || !canDeploy}
+                            disabled={!canDeploy}
                             className="w-full py-4 bg-cyan-600 hover:bg-cyan-500 disabled:bg-cyan-600/50 disabled:cursor-not-allowed text-white rounded-xl font-bold transition-all shadow-lg hover:shadow-cyan-500/25 flex justify-center items-center gap-2"
                         >
-                            {isDeploying ? (
-                                <>
-                                    <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
-                                    Deploying...
-                                </>
-                            ) : (
-                                <>Deploy Resource</>
-                            )}
+                            <>Continue to Billing</>
                         </button>
                     </div>
                 </div>

--- a/supabase/migrations/20260501120000_enforce_order_item_resources.sql
+++ b/supabase/migrations/20260501120000_enforce_order_item_resources.sql
@@ -1,0 +1,26 @@
+begin;
+
+-- Clean up legacy rows created during direct-provisioning that never had an order item.
+delete from public.service_resources
+where order_item_id is null
+  and created_at < timestamptz '2026-05-01 00:00:00+00';
+
+-- Enforce resource ownership through order items.
+alter table if exists public.service_resources
+  alter column order_item_id set not null;
+
+-- Ensure order item references stay consistent and cannot be orphaned.
+alter table if exists public.service_resources
+  drop constraint if exists service_resources_order_item_id_fkey;
+
+alter table if exists public.service_resources
+  add constraint service_resources_order_item_id_fkey
+  foreign key (order_item_id)
+  references public.order_items(id)
+  on delete restrict;
+
+-- One resource record per order item.
+create unique index if not exists service_resources_order_item_id_unique
+  on public.service_resources(order_item_id);
+
+commit;


### PR DESCRIPTION
### Motivation
- Ensure long-lived resources cannot be created without an associated paid order item by re-enforcing database constraints and eliminating legacy direct-provision rows. 
- Used skill: `supabase-postgres-best-practices` to guide the migration and constraint choices for data integrity and FK semantics.

### Description
- Add a migration `supabase/migrations/20260501120000_enforce_order_item_resources.sql` that deletes legacy `service_resources` with `order_item_id IS NULL`, sets `service_resources.order_item_id` to `NOT NULL`, recreates the FK to `order_items(id)` with `ON DELETE RESTRICT`, and creates a unique index on `service_resources(order_item_id)`.
- Add a standalone cleanup script `scripts/cleanup-direct-provision-service-resources.sql` that previews and deletes direct-provision-era rows with `order_item_id IS NULL`.
- Update the frontend `src/pages/dashboard/NewService.jsx` to stop direct provisioning and instead redirect users to billing checkout by navigating to `/dashboard/billing` with `intent=resource-order` and relevant parameters so resource creation follows the order→payment→resource flow.
- Add operational documentation `docs/migrations/20260501-order-item-resource-hardening.md` that details the migration, rollback SQL steps, and runbook notes (snapshot/PITR and pre-run cleanup recommendation).

### Testing
- Ran a production build with `npm run -s build` which completed successfully (Vite build succeeded, warning about large chunks only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40db59cc4832b8c04b13d59128932)