### PR TITLE
fix: clean legacy resources before order item constraint

### DIFF
--- a/supabase/migrations/20260501090000_reseller_order_orchestration.sql
+++ b/supabase/migrations/20260501090000_reseller_order_orchestration.sql
@@ -77,6 +77,9 @@ before insert or update on public.service_resources
 for each row execute function public.ensure_paid_order_item_for_service_resource();
 
 -- remove direct-null path once orchestration is live
+delete from public.service_resources
+where order_item_id is null;
+
 alter table public.service_resources
   alter column order_item_id set not null;
 


### PR DESCRIPTION
## Summary
- delete legacy service_resources rows with null order_item_id before the first migration tightens the column
- keeps the existing direct-null cleanup semantics, but moves it before the failing NOT NULL statement

## Verification
- git diff --check
- local Supabase replay unavailable: Docker daemon is not running on this machine
